### PR TITLE
forceLink no longer inconsistent across alpha

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -27,8 +27,8 @@ export default function(links) {
     for (var k = 0, n = links.length; k < iterations; ++k) {
       for (var i = 0, link, source, target, x, y, l, b; i < n; ++i) {
         link = links[i], source = link.source, target = link.target;
-        x = target.x + target.vx - source.x - source.vx || jiggle();
-        y = target.y + target.vy - source.y - source.vy || jiggle();
+        x = target.x - source.x || jiggle();
+        y = target.y - source.y || jiggle();
         l = Math.sqrt(x * x + y * y);
         l = (l - distances[i]) / l * alpha * strengths[i];
         x *= l, y *= l;


### PR DESCRIPTION
Removed velocity component of position calculation for nodes, as is already the case with manyBody and the positional force. This eliminates a behavior where the relative strenght of forceLink was inconsistent across different alpha. Further discussion on Issue 49 https://github.com/d3/d3-force/issues/49