### PR TITLE
force.initialize() without args no longer breaks

### DIFF
--- a/src/center.js
+++ b/src/center.js
@@ -21,7 +21,7 @@ export default function(x, y) {
   }
 
   force.initialize = function(_) {
-    nodes = _;
+    nodes = arguments.length ? _ : nodes;
   };
 
   force.x = function(_) {

--- a/src/collide.js
+++ b/src/collide.js
@@ -71,7 +71,7 @@ export default function(radius) {
   }
 
   force.initialize = function(_) {
-    var i, n = (nodes = _).length; radii = new Array(n);
+    var i, n = (nodes = arguments.length ? _ : nodes).length; radii = new Array(n);
     for (i = 0; i < n; ++i) radii[i] = +radius(nodes[i], i, nodes);
   };
 

--- a/src/link.js
+++ b/src/link.js
@@ -85,7 +85,7 @@ export default function(links) {
   }
 
   force.initialize = function(_) {
-    nodes = _;
+    nodes = arguments.length ? _ : nodes;
     initialize();
   };
 

--- a/src/manyBody.js
+++ b/src/manyBody.js
@@ -90,7 +90,7 @@ export default function() {
   }
 
   force.initialize = function(_) {
-    nodes = _;
+    nodes = arguments.length ? _ : nodes;
     initialize();
   };
 

--- a/src/x.js
+++ b/src/x.js
@@ -25,7 +25,7 @@ export default function(x) {
   }
 
   force.initialize = function(_) {
-    nodes = _;
+    nodes = arguments.length ? _ : nodes;
     initialize();
   };
 

--- a/src/y.js
+++ b/src/y.js
@@ -25,7 +25,7 @@ export default function(y) {
   }
 
   force.initialize = function(_) {
-    nodes = _;
+    nodes = arguments.length ? _ : nodes;
     initialize();
   };
 


### PR DESCRIPTION
force.initialize() can now be used to re-initialize a force without defining a
new set of nodes or functions, instead of counter-intuitively making the
force's nodes undefined.