### PR TITLE
Add support for 1D and 3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This method can be used in conjunction with [*simulation*.stop](#simulation_stop
 
 <a name="simulation_numDimensions" href="#simulation_numDimensions">#</a> <i>simulation</i>.<b>numDimensions</b>([<i>numDimensions</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L109 "Source")
 
-If *numDimensions* is specified, sets the simulation’s number of dimensions to use (1, 2 or 3), [re-initializes](#force_initialize) any bound [forces](#simulation_force) and returns the simulation. If *numSimulations* is not specified, returns the current simulation’s number of dimensions, which defauts to 2.
+If *numDimensions* is specified, sets the simulation’s number of dimensions to use (1, 2 or 3), [re-initializes](#force_initialize) any bound [forces](#simulation_force) and returns the simulation. If *numSimulations* is not specified, returns the current simulation’s number of dimensions, which defaults to 2.
 
 A one-dimensional simulation will only consider and manipulate the `x` and `vx` coordinate attributes, while a two-dimensional will extend the domain to `y` and `vy`, and a three-dimensional to `z` and `vz`.
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ var simulation = d3.forceSimulation(nodes);
 
 Creates a new simulation with the specified array of [*nodes*](#simulation_nodes) and no [forces](#simulation_force). If *nodes* is not specified, it defaults to the empty array. The simulator [starts](#simulation_restart) automatically; use [*simulation*.on](#simulation_on) to listen for tick events as the simulation runs. If you wish to run the simulation manually instead, call [*simulation*.stop](#simulation_stop), and then call [*simulation*.tick](#simulation_tick) as desired.
 
-<a name="simulation_restart" href="#simulation_restart">#</a> <i>simulation</i>.<b>restart</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L80 "Source")
+<a name="simulation_restart" href="#simulation_restart">#</a> <i>simulation</i>.<b>restart</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L101 "Source")
 
 Restarts the simulation’s internal timer and returns the simulation. In conjunction with [*simulation*.alphaTarget](#simulation_alphaTarget) or [*simulation*.alpha](#simulation_alpha), this method can be used to “reheat” the simulation during interaction, such as when dragging a node, or to resume the simulation after temporarily pausing it with [*simulation*.stop](#simulation_stop).
 
-<a name="simulation_stop" href="#simulation_stop">#</a> <i>simulation</i>.<b>stop</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L84 "Source")
+<a name="simulation_stop" href="#simulation_stop">#</a> <i>simulation</i>.<b>stop</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L105 "Source")
 
 Stops the simulation’s internal timer, if it is running, and returns the simulation. If the timer is already stopped, this method does nothing. This method is useful for running the simulation manually; see [*simulation*.tick](#simulation_tick).
 
-<a name="simulation_tick" href="#simulation_tick">#</a> <i>simulation</i>.<b>tick</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L38 "Source")
+<a name="simulation_tick" href="#simulation_tick">#</a> <i>simulation</i>.<b>tick</b>() [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L48 "Source")
 
 Increments the current [*alpha*](#simulation_alpha) by ([*alphaTarget*](#simulation_alphaTarget) - *alpha*) × [*alphaDecay*](#simulation_alphaDecay); then invokes each registered [force](#simulation_force), passing the new *alpha*; then decrements each [node](#simulation_nodes)’s velocity by *velocity* × [*velocityDecay*](#simulation_velocityDecay); lastly increments each node’s position by *velocity*.
 
@@ -59,7 +59,7 @@ This method does not dispatch [events](#simulation_on); events are only dispatch
 
 This method can be used in conjunction with [*simulation*.stop](#simulation_stop) to compute a [static force layout](https://bl.ocks.org/mbostock/1667139). For large graphs, static layouts should be computed [in a web worker](https://bl.ocks.org/mbostock/01ab2e85e8727d6529d20391c0fd9a16) to avoid freezing the user interface.
 
-<a name="simulation_nodes" href="#simulation_nodes">#</a> <i>simulation</i>.<b>nodes</b>([<i>nodes</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L88 "Source")
+<a name="simulation_nodes" href="#simulation_nodes">#</a> <i>simulation</i>.<b>nodes</b>([<i>nodes</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L115 "Source")
 
 If *nodes* is specified, sets the simulation’s nodes to the specified array of objects, initializing their positions and velocities if necessary, and then [re-initializes](#force_initialize) any bound [forces](#simulation_force); returns the simulation. If *nodes* is not specified, returns the simulation’s array of nodes as specified to the [constructor](#forceSimulation).
 
@@ -67,44 +67,47 @@ Each *node* must be an object. The following properties are assigned by the simu
 
 * `index` - the node’s zero-based index into *nodes*
 * `x` - the node’s current *x*-position
-* `y` - the node’s current *y*-position
+* `y` - the node’s current *y*-position (if using 2 or more dimensions)
+* `z` - the node’s current *z*-position (if using 3 dimensions)
 * `vx` - the node’s current *x*-velocity
-* `vy` - the node’s current *y*-velocity
+* `vy` - the node’s current *y*-velocity (if using 2 or more dimensions)
+* `vz` - the node’s current *z*-velocity (if using 3 dimensions)
 
-The position ⟨*x*,*y*⟩ and velocity ⟨*vx*,*vy*⟩ may be subsequently modified by [forces](#forces) and by the simulation. If either *vx* or *vy* is NaN, the velocity is initialized to ⟨0,0⟩. If either *x* or *y* is NaN, the position is initialized in a [phyllotaxis arrangement](http://bl.ocks.org/mbostock/11478058), so chosen to ensure a deterministic, uniform distribution around the origin.
+The position ⟨*x*[,*y*[,*z*]]⟩ and velocity ⟨*vx*[,*vy*[,*vz*]]⟩ may be subsequently modified by [forces](#forces) and by the simulation. If either applicable *vx*, *vy* or *vz* is NaN, the velocity is initialized to ⟨0,0,0⟩. If either applicable *x*, *y* or *z* is NaN, the 2D position is initialized in a [phyllotaxis arrangement](http://bl.ocks.org/mbostock/11478058), so chosen to ensure a deterministic, uniform distribution around the origin.
 
-To fix a node in a given position, you may specify two additional properties:
+To fix a node in a given position, you may specify three additional properties:
 
 * `fx` - the node’s fixed *x*-position
 * `fy` - the node’s fixed *y*-position
+* `fz` - the node’s fixed *z*-position
 
-At the end of each [tick](#simulation_tick), after the application of any forces, a node with a defined *node*.fx has *node*.x reset to this value and *node*.vx set to zero; likewise, a node with a defined *node*.fy has *node*.y reset to this value and *node*.vy set to zero. To unfix a node that was previously fixed, set *node*.fx and *node*.fy to null, or delete these properties.
+At the end of each [tick](#simulation_tick), after the application of any forces, a node with a defined *node*.fx has *node*.x reset to this value and *node*.vx set to zero; likewise, in 2 dimensions or higher a node with a defined *node*.fy has *node*.y reset to this value and *node*.vy set to zero, and in 3-dimensions a node with a defined *node*.fz has *node*.z reset to this value and *node*.vz set to zero. To unfix a node that was previously fixed, set *node*.fx, *node*.fy and *node*.fz to null, or delete these properties.
 
 If the specified array of *nodes* is modified, such as when nodes are added to or removed from the simulation, this method must be called again with the new (or changed) array to notify the simulation and bound forces of the change; the simulation does not make a defensive copy of the specified array.
 
-<a name="simulation_alpha" href="#simulation_alpha">#</a> <i>simulation</i>.<b>alpha</b>([<i>alpha</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L92 "Source")
+<a name="simulation_alpha" href="#simulation_alpha">#</a> <i>simulation</i>.<b>alpha</b>([<i>alpha</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L119 "Source")
 
 If *alpha* is specified, sets the current alpha to the specified number in the range [0,1] and returns this simulation. If *alpha* is not specified, returns the current alpha value, which defaults to 1.
 
-<a name="simulation_alphaMin" href="#simulation_alphaMin">#</a> <i>simulation</i>.<b>alphaMin</b>([<i>min</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L96 "Source")
+<a name="simulation_alphaMin" href="#simulation_alphaMin">#</a> <i>simulation</i>.<b>alphaMin</b>([<i>min</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L123 "Source")
 
 If *min* is specified, sets the minimum *alpha* to the specified number in the range [0,1] and returns this simulation. If *min* is not specified, returns the current minimum *alpha* value, which defaults to 0.001. The simulation’s internal timer stops when the current [*alpha*](#simulation_alpha) is less than the minimum *alpha*. The default [alpha decay rate](#simulation_alphaDecay) of ~0.0228 corresponds to 300 iterations.
 
-<a name="simulation_alphaDecay" href="#simulation_alphaDecay">#</a> <i>simulation</i>.<b>alphaDecay</b>([<i>decay</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L100 "Source")
+<a name="simulation_alphaDecay" href="#simulation_alphaDecay">#</a> <i>simulation</i>.<b>alphaDecay</b>([<i>decay</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L127 "Source")
 
 If *decay* is specified, sets the [*alpha*](#simulation_alpha) decay rate to the specified number in the range [0,1] and returns this simulation. If *decay* is not specified, returns the current *alpha* decay rate, which defaults to 0.0228… = 1 - *pow*(0.001, 1 / 300) where 0.001 is the default [minimum *alpha*](#simulation_alphaMin).
 
 The alpha decay rate determines how quickly the current alpha interpolates towards the desired [target *alpha*](#simulation_alphaTarget); since the default target *alpha* is zero, by default this controls how quickly the simulation cools. Higher decay rates cause the simulation to stabilize more quickly, but risk getting stuck in a local minimum; lower values cause the simulation to take longer to run, but typically converge on a better layout. To have the simulation run forever at the current *alpha*, set the *decay* rate to zero; alternatively, set a [target *alpha*](#simulation_alphaTarget) greater than the [minimum *alpha*](#simulation_alphaMin).
 
-<a name="simulation_alphaTarget" href="#simulation_alphaTarget">#</a> <i>simulation</i>.<b>alphaTarget</b>([<i>target</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L104 "Source")
+<a name="simulation_alphaTarget" href="#simulation_alphaTarget">#</a> <i>simulation</i>.<b>alphaTarget</b>([<i>target</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L131 "Source")
 
 If *target* is specified, sets the current target [*alpha*](#simulation_alpha) to the specified number in the range [0,1] and returns this simulation. If *target* is not specified, returns the current target alpha value, which defaults to 0.
 
-<a name="simulation_velocityDecay" href="#simulation_velocityDecay">#</a> <i>simulation</i>.<b>velocityDecay</b>([<i>decay</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L108 "Source")
+<a name="simulation_velocityDecay" href="#simulation_velocityDecay">#</a> <i>simulation</i>.<b>velocityDecay</b>([<i>decay</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L135 "Source")
 
 If *decay* is specified, sets the velocity decay factor to the specified number in the range [0,1] and returns this simulation. If *decay* is not specified, returns the current velocity decay factor, which defaults to 0.4. The decay factor is akin to atmospheric friction; after the application of any forces during a [tick](#simulation_tick), each node’s velocity is multiplied by 1 - *decay*. As with lowering the [alpha decay rate](#simulation_alphaDecay), less velocity decay may converge on a better solution, but risks numerical instabilities and oscillation.
 
-<a name="simulation_force" href="#simulation_force">#</a> <i>simulation</i>.<b>force</b>(<i>name</i>[, <i>force</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L112 "Source")
+<a name="simulation_force" href="#simulation_force">#</a> <i>simulation</i>.<b>force</b>(<i>name</i>[, <i>force</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L139 "Source")
 
 If *force* is specified, assigns the [force](#forces) for the specified *name* and returns this simulation. If *force* is not specified, returns the force with the specified name, or undefined if there is no such force. (By default, new simulations have no forces.) For example, to create a new simulation to layout a graph, you might say:
 
@@ -115,11 +118,11 @@ var simulation = d3.forceSimulation(nodes)
     .force("center", d3.forceCenter());
 ```
 
-<a name="simulation_find" href="#simulation_find">#</a> <i>simulation</i>.<b>find</b>(<i>x</i>, <i>y</i>[, <i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L116 "Source")
+<a name="simulation_find" href="#simulation_find">#</a> <i>simulation</i>.<b>find</b>(<i>x</i>[, <i>y</i>[, <i>z</i>]][, <i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L143 "Source")
 
-Returns the node closest to the position ⟨*x*,*y*⟩ with the given search *radius*. If *radius* is not specified, it defaults to infinity. If there is no node within the search area, returns undefined.
+Returns the node closest to the position ⟨*x*,*y*,*z*⟩ with the given search *radius*. If *radius* is not specified, it defaults to infinity. If there is no node within the search area, returns undefined.
 
-<a name="simulation_on" href="#simulation_on">#</a> <i>simulation</i>.<b>on</b>(<i>typenames</i>, [<i>listener</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L139 "Source")
+<a name="simulation_on" href="#simulation_on">#</a> <i>simulation</i>.<b>on</b>(<i>typenames</i>, [<i>listener</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L173 "Source")
 
 If *listener* is specified, sets the event *listener* for the specified *typenames* and returns this simulation. If an event listener was already registered for the same type and name, the existing listener is removed before the new listener is added. If *listener* is null, removes the current event listeners for the specified *typenames*, if any. If *listener* is not specified, returns the first currently-assigned listener matching the specified *typenames*, if any. When a specified event is dispatched, each *listener* will be invoked with the `this` context as the simulation.
 
@@ -134,7 +137,7 @@ See [*dispatch*.on](https://github.com/d3/d3-dispatch#dispatch_on) for details.
 
 ### Forces
 
-A *force* is simply a function that modifies nodes’ positions or velocities; in this context, a *force* can apply a classical physical force such as electrical charge or gravity, or it can resolve a geometric constraint, such as keeping nodes within a bounding box or keeping linked nodes a fixed distance apart. For example, a simple positioning force that moves nodes towards the origin ⟨0,0⟩ might be implemented as:
+A *force* is simply a function that modifies nodes’ positions or velocities; in this context, a *force* can apply a classical physical force such as electrical charge or gravity, or it can resolve a geometric constraint, such as keeping nodes within a bounding box or keeping linked nodes a fixed distance apart. For example, a simple positioning force that moves nodes towards the origin ⟨0,0,0⟩ in a 2D simulation might be implemented as:
 
 ```js
 function force(alpha) {
@@ -146,7 +149,7 @@ function force(alpha) {
 }
 ```
 
-Forces typically read the node’s current position ⟨*x*,*y*⟩ and then add to (or subtract from) the node’s velocity ⟨*vx*,*vy*⟩. However, forces may also “peek ahead” to the anticipated next position of the node, ⟨*x* + *vx*,*y* + *vy*⟩; this is necessary for resolving geometric constraints through [iterative relaxation](https://en.wikipedia.org/wiki/Relaxation_\(iterative_method\)). Forces may also modify the position directly, which is sometimes useful to avoid adding energy to the simulation, such as when recentering the simulation in the viewport.
+Forces typically read the node’s current position ⟨*x*,*y*,*z*⟩ and then add to (or subtract from) the node’s velocity ⟨*vx*,*vy*,*vz*⟩. However, forces may also “peek ahead” to the anticipated next position of the node, ⟨*x* + *vx*,*y* + *vy*,*z* + *vz*⟩; this is necessary for resolving geometric constraints through [iterative relaxation](https://en.wikipedia.org/wiki/Relaxation_\(iterative_method\)). Forces may also modify the position directly, which is sometimes useful to avoid adding energy to the simulation, such as when recentering the simulation in the viewport.
 
 Simulations typically compose multiple forces as desired. This module provides several for your enjoyment:
 
@@ -158,39 +161,43 @@ Simulations typically compose multiple forces as desired. This module provides s
 
 Forces may optionally implement [*force*.initialize](#force_initialize) to receive the simulation’s array of nodes.
 
-<a name="_force" href="#_force">#</a> <i>force</i>(<i>alpha</i>) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L44 "Source")
+<a name="_force" href="#_force">#</a> <i>force</i>(<i>alpha</i>) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L54 "Source")
 
 Applies this force, optionally observing the specified *alpha*. Typically, the force is applied to the array of nodes previously passed to [*force*.initialize](#force_initialize), however, some forces may apply to a subset of nodes, or behave differently. For example, [d3.forceLink](#links) applies to the source and target of each link.
 
-<a name="force_initialize" href="#force_initialize">#</a> <i>force</i>.<b>initialize</b>(<i>nodes</i>) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L71 "Source")
+<a name="force_initialize" href="#force_initialize">#</a> <i>force</i>.<b>initialize</b>(<i>nodes</i>) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L92 "Source")
 
 Assigns the array of *nodes* to this force. This method is called when a force is bound to a simulation via [*simulation*.force](#simulation_force) and when the simulation’s nodes change via [*simulation*.nodes](#simulation_nodes). A force may perform necessary work during initialization, such as evaluating per-node parameters, to avoid repeatedly performing work during each application of the force.
 
 #### Centering
 
-The centering force translates nodes uniformly so that the mean position of all nodes (the center of mass if all nodes have equal weight) is at the given position ⟨[*x*](#center_x),[*y*](#center_y)⟩. This force modifies the positions of nodes on each application; it does not modify velocities, as doing so would typically cause the nodes to overshoot and oscillate around the desired center. This force helps keeps nodes in the center of the viewport, and unlike the [positioning force](#positioning), it does not distort their relative positions.
+The centering force translates nodes uniformly so that the mean position of all nodes (the center of mass if all nodes have equal weight) is at the given position ⟨[*x*](#center_x),[*y*](#center_y),[*z*](#center_z)⟩. This force modifies the positions of nodes on each application; it does not modify velocities, as doing so would typically cause the nodes to overshoot and oscillate around the desired center. This force helps keeps nodes in the center of the viewport, and unlike the [positioning force](#positioning), it does not distort their relative positions.
 
-<a name="forceCenter" href="#forceCenter">#</a> d3.<b>forceCenter</b>([<i>x</i>, <i>y</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L1 "Source")
+<a name="forceCenter" href="#forceCenter">#</a> d3.<b>forceCenter</b>([<i>x</i>[, <i>y</i>[, <i>y</i>]]]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L1 "Source")
 
-Creates a new centering force with the specified [*x*-](#center_x) and [*y*-](#center_y) coordinates. If *x* and *y* are not specified, they default to ⟨0,0⟩.
+Creates a new centering force with the specified [*x*-](#center_x), [*y*-](#center_y) and [*z*-](#center_z) coordinates. If *x*, *y* and *z* are not specified, they default to ⟨0,0,0⟩.
 
-<a name="center_x" href="#center_x">#</a> <i>center</i>.<b>x</b>([<i>x</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L27 "Source")
+<a name="center_x" href="#center_x">#</a> <i>center</i>.<b>x</b>([<i>x</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L32 "Source")
 
 If *x* is specified, sets the *x*-coordinate of the centering position to the specified number and returns this force. If *x* is not specified, returns the current *x*-coordinate, which defaults to zero.
 
-<a name="center_y" href="#center_y">#</a> <i>center</i>.<b>y</b>([<i>y</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L31 "Source")
+<a name="center_y" href="#center_y">#</a> <i>center</i>.<b>y</b>([<i>y</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L36 "Source")
 
 If *y* is specified, sets the *y*-coordinate of the centering position to the specified number and returns this force. If *y* is not specified, returns the current *y*-coordinate, which defaults to zero.
 
+<a name="center_z" href="#center_z">#</a> <i>center</i>.<b>z</b>([<i>z</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/center.js#L40 "Source")
+
+If *z* is specified, sets the *z*-coordinate of the centering position to the specified number and returns this force. If *z* is not specified, returns the current *z*-coordinate, which defaults to zero.
+
 #### Collision
 
-The collision force treats nodes as circles with a given [radius](#collide_radius), rather than points, and prevents nodes from overlapping. More formally, two nodes *a* and *b* are separated so that the distance between *a* and *b* is at least *radius*(*a*) + *radius*(*b*). To reduce jitter, this is by default a “soft” constraint with a configurable [strength](#collide_strength) and [iteration count](#collide_iterations).
+The collision force treats nodes as lengths, circles or spheres (respectively for 1D, 2D or 3D) with a given [radius](#collide_radius), rather than points, and prevents nodes from overlapping. More formally, two nodes *a* and *b* are separated so that the distance between *a* and *b* is at least *radius*(*a*) + *radius*(*b*). To reduce jitter, this is by default a “soft” constraint with a configurable [strength](#collide_strength) and [iteration count](#collide_iterations).
 
 <a name="forceCollide" href="#forceCollide">#</a> d3.<b>forceCollide</b>([<i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js "Source")
 
 Creates a new circle collision force with the specified [*radius*](#collide_radius). If *radius* is not specified, it defaults to the constant one for all nodes.
 
-<a name="collide_radius" href="#collide_radius">#</a> <i>collide</i>.<b>radius</b>([<i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L86 "Source")
+<a name="collide_radius" href="#collide_radius">#</a> <i>collide</i>.<b>radius</b>([<i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L126 "Source")
 
 If *radius* is specified, sets the radius accessor to the specified number or function, re-evaluates the radius accessor for each node, and returns this force. If *radius* is not specified, returns the current radius accessor, which defaults to:
 
@@ -202,13 +209,13 @@ function radius() {
 
 The radius accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the radius of each node is only recomputed when the force is initialized or when this method is called with a new *radius*, and not on every application of the force.
 
-<a name="collide_strength" href="#collide_strength">#</a> <i>collide</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L82 "Source")
+<a name="collide_strength" href="#collide_strength">#</a> <i>collide</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L122 "Source")
 
 If *strength* is specified, sets the force strength to the specified number in the range [0,1] and returns this force. If *strength* is not specified, returns the current strength which defaults to 0.7.
 
-Overlapping nodes are resolved through iterative relaxation. For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions ⟨*x* + *vx*,*y* + *vy*⟩) are determined; the node’s velocity is then modified to push the node out of each overlapping node. The change in velocity is dampened by the force’s strength such that the resolution of simultaneous overlaps can be blended together to find a stable solution.
+Overlapping nodes are resolved through iterative relaxation. For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions ⟨*x* + *vx*,*y* + *vy*,*z* + *vz*⟩) are determined; the node’s velocity is then modified to push the node out of each overlapping node. The change in velocity is dampened by the force’s strength such that the resolution of simultaneous overlaps can be blended together to find a stable solution.
 
-<a name="collide_iterations" href="#collide_iterations">#</a> <i>collide</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L78 "Source")
+<a name="collide_iterations" href="#collide_iterations">#</a> <i>collide</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/collide.js#L118 "Source")
 
 If *iterations* is specified, sets the number of iterations per application to the specified number and returns this force. If *iterations* is not specified, returns the current iteration count which defaults to 1. Increasing the number of iterations greatly increases the rigidity of the constraint and avoids partial overlap of nodes, but also increases the runtime cost to evaluate the force.
 
@@ -220,7 +227,7 @@ The link force pushes linked nodes together or apart according to the desired [l
 
 Creates a new link force with the specified *links* and default parameters. If *links* is not specified, it defaults to the empty array.
 
-<a name="link_links" href="#link_links">#</a> <i>link</i>.<b>links</b>([<i>links</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L92 "Source")
+<a name="link_links" href="#link_links">#</a> <i>link</i>.<b>links</b>([<i>links</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L103 "Source")
 
 If *links* is specified, sets the array of links associated with this force, recomputes the [distance](#link_distance) and [strength](#link_strength) parameters for each link, and returns this force. If *links* is not specified, returns the current array of links, which defaults to the empty array.
 
@@ -234,7 +241,7 @@ For convenience, a link’s source and target properties may be initialized usin
 
 If the specified array of *links* is modified, such as when links are added to or removed from the simulation, this method must be called again with the new (or changed) array to notify the force of the change; the force does not make a defensive copy of the specified array.
 
-<a name="link_id" href="#link_id">#</a> <i>link</i>.<b>id</b>([<i>id</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L96 "Source")
+<a name="link_id" href="#link_id">#</a> <i>link</i>.<b>id</b>([<i>id</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L107 "Source")
 
 If *id* is specified, sets the node id accessor to the specified function and returns this force. If *id* is not specified, returns the current node id accessor, which defaults to the numeric *node*.index:
 
@@ -286,7 +293,7 @@ This is particularly useful when representing graphs in JSON, as JSON does not a
 
 The id accessor is invoked for each node whenever the force is initialized, as when the [nodes](#simulation_nodes) or [links](#link_links) change, being passed the node and its zero-based index.
 
-<a name="link_distance" href="#link_distance">#</a> <i>link</i>.<b>distance</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L108 "Source")
+<a name="link_distance" href="#link_distance">#</a> <i>link</i>.<b>distance</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L119 "Source")
 
 If *distance* is specified, sets the distance accessor to the specified number or function, re-evaluates the distance accessor for each link, and returns this force. If *distance* is not specified, returns the current distance accessor, which defaults to:
 
@@ -298,7 +305,7 @@ function distance() {
 
 The distance accessor is invoked for each [link](#link_links), being passed the *link* and its zero-based *index*. The resulting number is then stored internally, such that the distance of each link is only recomputed when the force is initialized or when this method is called with a new *distance*, and not on every application of the force.
 
-<a name="link_strength" href="#link_strength">#</a> <i>link</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L104 "Source")
+<a name="link_strength" href="#link_strength">#</a> <i>link</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L115 "Source")
 
 If *strength* is specified, sets the strength accessor to the specified number or function, re-evaluates the strength accessor for each link, and returns this force. If *strength* is not specified, returns the current strength accessor, which defaults to:
 
@@ -312,7 +319,7 @@ Where *count*(*node*) is a function that returns the number of links with the gi
 
 The strength accessor is invoked for each [link](#link_links), being passed the *link* and its zero-based *index*. The resulting number is then stored internally, such that the strength of each link is only recomputed when the force is initialized or when this method is called with a new *strength*, and not on every application of the force.
 
-<a name="link_iterations" href="#link_iterations">#</a> <i>link</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L100 "Source")
+<a name="link_iterations" href="#link_iterations">#</a> <i>link</i>.<b>iterations</b>([<i>iterations</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/link.js#L111 "Source")
 
 If *iterations* is specified, sets the number of iterations per application to the specified number and returns this force. If *iterations* is not specified, returns the current iteration count which defaults to 1. Increasing the number of iterations greatly increases the rigidity of the constraint and is useful for [complex structures such as lattices](http://bl.ocks.org/mbostock/1b64ec067fcfc51e7471d944f51f1611), but also increases the runtime cost to evaluate the force.
 
@@ -326,7 +333,7 @@ Unlike links, which only affect two linked nodes, the charge force is global: ev
 
 Creates a new many-body force with the default parameters.
 
-<a name="manyBody_strength" href="#manyBody_strength">#</a> <i>manyBody</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L97 "Source")
+<a name="manyBody_strength" href="#manyBody_strength">#</a> <i>manyBody</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L118 "Source")
 
 If *strength* is specified, sets the strength accessor to the specified number or function, re-evaluates the strength accessor for each node, and returns this force. A positive value causes nodes to attract each other, similar to gravity, while a negative value causes nodes to repel each other, similar to electrostatic charge. If *strength* is not specified, returns the current strength accessor, which defaults to:
 
@@ -338,23 +345,23 @@ function strength() {
 
 The strength accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or when this method is called with a new *strength*, and not on every application of the force.
 
-<a name="manyBody_theta" href="#manyBody_theta">#</a> <i>manyBody</i>.<b>theta</b>([<i>theta</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L109 "Source")
+<a name="manyBody_theta" href="#manyBody_theta">#</a> <i>manyBody</i>.<b>theta</b>([<i>theta</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L130 "Source")
 
 If *theta* is specified, sets the Barnes–Hut approximation criterion to the specified number and returns this force. If *theta* is not specified, returns the current value, which defaults to 0.9.
 
 To accelerate computation, this force implements the [Barnes–Hut approximation](http://en.wikipedia.org/wiki/Barnes–Hut_simulation) which takes O(*n* log *n*) per application where *n* is the number of [nodes](#simulation_nodes). For each application, a [quadtree](https://github.com/d3/d3-quadtree) stores the current node positions; then for each node, the combined force of all other nodes on the given node is computed. For a cluster of nodes that is far away, the charge force can be approximated by treating the cluster as a single, larger node. The *theta* parameter determines the accuracy of the approximation: if the ratio *w* / *l* of the width *w* of the quadtree cell to the distance *l* from the node to the cell’s center of mass is less than *theta*, all nodes in the given cell are treated as a single node rather than individually.
 
-<a name="manyBody_distanceMin" href="#manyBody_distanceMin">#</a> <i>manyBody</i>.<b>distanceMin</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L101 "Source")
+<a name="manyBody_distanceMin" href="#manyBody_distanceMin">#</a> <i>manyBody</i>.<b>distanceMin</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L122 "Source")
 
 If *distance* is specified, sets the minimum distance between nodes over which this force is considered. If *distance* is not specified, returns the current minimum distance, which defaults to 1. A minimum distance establishes an upper bound on the strength of the force between two nearby nodes, avoiding instability. In particular, it avoids an infinitely-strong force if two nodes are exactly coincident; in this case, the direction of the force is random.
 
-<a name="manyBody_distanceMax" href="#manyBody_distanceMax">#</a> <i>manyBody</i>.<b>distanceMax</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L105 "Source")
+<a name="manyBody_distanceMax" href="#manyBody_distanceMax">#</a> <i>manyBody</i>.<b>distanceMax</b>([<i>distance</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/manyBody.js#L126 "Source")
 
 If *distance* is specified, sets the maximum distance between nodes over which this force is considered. If *distance* is not specified, returns the current maximum distance, which defaults to infinity. Specifying a finite maximum distance improves performance and produces a more localized layout.
 
 #### Positioning
 
-The [*x*](#forceX)- and [*y*](#forceY)-positioning forces push nodes towards a desired position along the given dimension with a configurable strength. The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position. While these forces can be used to position individual nodes, they are intended primarily for global forces that apply to all (or most) nodes.
+The [*x*](#forceX)-, [*y*](#forceY)- and [*z*](#forceZ)-positioning forces push nodes towards a desired position along the given dimension with a configurable strength. The strength of the force is proportional to the one-dimensional distance between the node’s position and the target position. While these forces can be used to position individual nodes, they are intended primarily for global forces that apply to all (or most) nodes.
 
 <a name="forceX" href="#forceX">#</a> d3.<b>forceX</b>([<i>x</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/x.js "Source")
 
@@ -415,3 +422,33 @@ function y() {
 ```
 
 The *y*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *y*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *y*, and not on every application of the force.
+
+<a name="forceZ" href="#forcez">#</a> d3.<b>forcez</b>([<i>z</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/z.js "Source")
+
+Creates a new positioning force along the *z*-axis towards the given position [*z*](#z_z). If *z* is not specified, it defaults to 0.
+
+<a name="z_strength" href="#z_strength">#</a> <i>z</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/z.js#L32 "Source")
+
+If *strength* is specified, sets the strength accessor to the specified number or function, re-evaluates the strength accessor for each node, and returns this force. The *strength* determines how much to increment the node’s *z*-velocity: ([*z*](#z_z) - *node*.z) × *strength*. For example, a value of 0.1 indicates that the node should move a tenth of the way from its current *z*-position to the target *z*-position with each application. Higher values moves nodes more quickly to the target position, often at the expense of other forces or constraints. A value outside the range [0,1] is not recommended.
+
+If *strength* is not specified, returns the current strength accessor, which defaults to:
+
+```js
+function strength() {
+  return 0.1;
+}
+```
+
+The strength accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the strength of each node is only recomputed when the force is initialized or when this method is called with a new *strength*, and not on every application of the force.
+
+<a name="z_z" href="#z_z">#</a> <i>z</i>.<b>z</b>([<i>z</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/z.js#L36 "Source")
+
+If *z* is specified, sets the *z*-coordinate accessor to the specified number or function, re-evaluates the *z*-accessor for each node, and returns this force. If *z* is not specified, returns the current *z*-accessor, which defaults to:
+
+```js
+function z() {
+  return 0;
+}
+```
+
+The *z*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *z*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *z*, and not on every application of the force.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ This method does not dispatch [events](#simulation_on); events are only dispatch
 
 This method can be used in conjunction with [*simulation*.stop](#simulation_stop) to compute a [static force layout](https://bl.ocks.org/mbostock/1667139). For large graphs, static layouts should be computed [in a web worker](https://bl.ocks.org/mbostock/01ab2e85e8727d6529d20391c0fd9a16) to avoid freezing the user interface.
 
+<a name="simulation_numDimensions" href="#simulation_numDimensions">#</a> <i>simulation</i>.<b>numDimensions</b>([<i>numDimensions</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L109 "Source")
+
+If *numDimensions* is specified, sets the simulation’s number of dimensions to use (1, 2 or 3), [re-initializes](#force_initialize) any bound [forces](#simulation_force) and returns the simulation. If *numSimulations* is not specified, returns the current simulation’s number of dimensions, which defauts to 2.
+
+A one-dimensional simulation will only consider and manipulate the `x` and `vx` coordinate attributes, while a two-dimensional will extend the domain to `y` and `vy`, and a three-dimensional to `z` and `vz`.
+
 <a name="simulation_nodes" href="#simulation_nodes">#</a> <i>simulation</i>.<b>nodes</b>([<i>nodes</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/simulation.js#L115 "Source")
 
 If *nodes* is specified, sets the simulation’s nodes to the specified array of objects, initializing their positions and velocities if necessary, and then [re-initializes](#force_initialize) any bound [forces](#simulation_force); returns the simulation. If *nodes* is not specified, returns the simulation’s array of nodes as specified to the [constructor](#forceSimulation).

--- a/index.js
+++ b/index.js
@@ -5,3 +5,4 @@ export {default as forceManyBody} from "./src/manyBody";
 export {default as forceSimulation} from "./src/simulation";
 export {default as forceX} from "./src/x";
 export {default as forceY} from "./src/y";
+export {default as forceZ} from "./src/z";

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/d3/d3-force.git"
   },
   "scripts": {
-    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -g d3-collection:d3,d3-dispatch:d3,d3-quadtree:d3,d3-timer:d3 -f umd -n d3 -o build/d3-force.js -- index.js",
+    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -g d3-collection:d3,d3-dispatch:d3,d3-binarytree:d3,d3-quadtree:d3,d3-octree:d3,d3-timer:d3 -f umd -n d3 -o build/d3-force.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-force.js -c -m -o build/d3-force.min.js",
     "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-force/build/d3-force.js d3-force.v1.js && cp ../d3-force/build/d3-force.min.js d3-force.v1.min.js && git add d3-force.v1.js d3-force.v1.min.js && git commit -m \"d3-force ${npm_package_version}\" && git push && cd - && zip -j build/d3-force.zip -- LICENSE README.md build/d3-force.js build/d3-force.min.js"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-force/build/d3-force.js d3-force.v1.js && cp ../d3-force/build/d3-force.min.js d3-force.v1.min.js && git add d3-force.v1.js d3-force.v1.min.js && git commit -m \"d3-force ${npm_package_version}\" && git push && cd - && zip -j build/d3-force.zip -- LICENSE README.md build/d3-force.js build/d3-force.min.js"
   },
   "dependencies": {
+    "d3-binarytree": "~0.1",
     "d3-collection": "1",
     "d3-dispatch": "1",
+    "d3-octree": "~0.1",
     "d3-quadtree": "1",
     "d3-timer": "1"
   },

--- a/src/center.js
+++ b/src/center.js
@@ -1,22 +1,27 @@
-export default function(x, y) {
+export default function(x, y, z) {
   var nodes;
 
   if (x == null) x = 0;
   if (y == null) y = 0;
+  if (z == null) z = 0;
 
   function force() {
     var i,
         n = nodes.length,
         node,
         sx = 0,
-        sy = 0;
+        sy = 0,
+        sz = 0;
 
     for (i = 0; i < n; ++i) {
-      node = nodes[i], sx += node.x, sy += node.y;
+      node = nodes[i], sx += node.x || 0, sy += node.y || 0, sz += node.z || 0;
     }
 
-    for (sx = sx / n - x, sy = sy / n - y, i = 0; i < n; ++i) {
-      node = nodes[i], node.x -= sx, node.y -= sy;
+    for (sx = sx / n - x, sy = sy / n - y, sz = sz / n - z, i = 0; i < n; ++i) {
+      node = nodes[i];
+      if (sx) { node.x -= sx }
+      if (sy) { node.y -= sy; }
+      if (sz) { node.z -= sz; }
     }
   }
 
@@ -30,6 +35,10 @@ export default function(x, y) {
 
   force.y = function(_) {
     return arguments.length ? (y = +_, force) : y;
+  };
+
+  force.z = function(_) {
+    return arguments.length ? (z = +_, force) : z;
   };
 
   return force;

--- a/src/collide.js
+++ b/src/collide.js
@@ -87,8 +87,8 @@ export default function(radius) {
         return;
       }
       return x0 > xi + r || x1 < xi - r
-          || (numDim > 1 && (y0 > yi + r || y1 < yi - r))
-          || (numDim > 2 && (z0 > zi + r || z1 < zi - r));
+          || (nDim > 1 && (y0 > yi + r || y1 < yi - r))
+          || (nDim > 2 && (z0 > zi + r || z1 < zi - r));
     }
   }
 

--- a/src/collide.js
+++ b/src/collide.js
@@ -53,14 +53,8 @@ export default function(radius) {
       }
     }
 
-    function apply(treeNode) {
-      var args = Array.prototype.slice.call(arguments);
-      if (nDim > 2) { var z1 = args.pop(); }
-      if (nDim > 1) { var y1 = args.pop(); }
-      var x1 = args.pop();
-      if (nDim > 2) { var z0 = args.pop(); }
-      if (nDim > 1) { var y0 = args.pop(); }
-      var x0 = args.pop();
+    function apply(treeNode, x0, arg1, arg2, arg3) {
+      var x1 = [arg1, arg2, arg3][nDim-1];
 
       var data = treeNode.data, rj = treeNode.r, r = ri + rj;
       if (data) {

--- a/src/collide.js
+++ b/src/collide.js
@@ -1,6 +1,8 @@
 import constant from "./constant";
 import jiggle from "./jiggle";
+import {binarytree} from "d3-binarytree";
 import {quadtree} from "d3-quadtree";
+import {octree} from "d3-octree";
 
 function x(d) {
   return d.x + d.vx;
@@ -10,8 +12,13 @@ function y(d) {
   return d.y + d.vy;
 }
 
+function z(d) {
+  return d.z + d.vz;
+}
+
 export default function(radius) {
   var nodes,
+      nDim,
       radii,
       strength = 1,
       iterations = 1;
@@ -24,48 +31,72 @@ export default function(radius) {
         node,
         xi,
         yi,
+        zi,
         ri,
         ri2;
 
     for (var k = 0; k < iterations; ++k) {
-      tree = quadtree(nodes, x, y).visitAfter(prepare);
+      tree =
+          (nDim === 1 ? binarytree(nodes, x)
+          :(nDim === 2 ? quadtree(nodes, x, y)
+          :(nDim === 3 ? octree(nodes, x, y, z)
+          :null
+      ))).visitAfter(prepare);
+
       for (i = 0; i < n; ++i) {
         node = nodes[i];
         ri = radii[node.index], ri2 = ri * ri;
         xi = node.x + node.vx;
-        yi = node.y + node.vy;
+        if (nDim > 1) { yi = node.y + node.vy; }
+        if (nDim > 2) { zi = node.z + node.vz; }
         tree.visit(apply);
       }
     }
 
-    function apply(quad, x0, y0, x1, y1) {
-      var data = quad.data, rj = quad.r, r = ri + rj;
+    function apply(treeNode) {
+      var args = Array.prototype.slice.call(arguments);
+      if (nDim > 2) { var z1 = args.pop(); }
+      if (nDim > 1) { var y1 = args.pop(); }
+      var x1 = args.pop();
+      if (nDim > 2) { var z0 = args.pop(); }
+      if (nDim > 1) { var y0 = args.pop(); }
+      var x0 = args.pop();
+
+      var data = treeNode.data, rj = treeNode.r, r = ri + rj;
       if (data) {
         if (data.index > node.index) {
           var x = xi - data.x - data.vx,
-              y = yi - data.y - data.vy,
-              l = x * x + y * y;
+              y = (nDim > 1 ? yi - data.y - data.vy : 0),
+              z = (nDim > 2 ? zi - data.z - data.vz : 0),
+              l = x * x + y * y + z * z;
           if (l < r * r) {
             if (x === 0) x = jiggle(), l += x * x;
-            if (y === 0) y = jiggle(), l += y * y;
+            if (nDim > 1 && y === 0) y = jiggle(), l += y * y;
+            if (nDim > 2 && z === 0) z = jiggle(), l += z * z;
             l = (r - (l = Math.sqrt(l))) / l * strength;
+
             node.vx += (x *= l) * (r = (rj *= rj) / (ri2 + rj));
-            node.vy += (y *= l) * r;
+            if (nDim > 1) { node.vy += (y *= l) * r; }
+            if (nDim > 2) { node.vz += (z *= l) * r; }
+
             data.vx -= x * (r = 1 - r);
-            data.vy -= y * r;
+            if (nDim > 1) { data.vy -= y * r; }
+            if (nDim > 2) { data.vz -= z * r; }
           }
         }
         return;
       }
-      return x0 > xi + r || x1 < xi - r || y0 > yi + r || y1 < yi - r;
+      return x0 > xi + r || x1 < xi - r
+          || (numDim > 1 && (y0 > yi + r || y1 < yi - r))
+          || (numDim > 2 && (z0 > zi + r || z1 < zi - r));
     }
   }
 
-  function prepare(quad) {
-    if (quad.data) return quad.r = radii[quad.data.index];
-    for (var i = quad.r = 0; i < 4; ++i) {
-      if (quad[i] && quad[i].r > quad.r) {
-        quad.r = quad[i].r;
+  function prepare(treeNode) {
+    if (treeNode.data) return treeNode.r = radii[treeNode.data.index];
+    for (var i = treeNode.r = 0; i < Math.pow(2, nDim); ++i) {
+      if (treeNode[i] && treeNode[i].r > treeNode.r) {
+        treeNode.r = treeNode[i].r;
       }
     }
   }
@@ -77,8 +108,9 @@ export default function(radius) {
     for (i = 0; i < n; ++i) node = nodes[i], radii[node.index] = +radius(node, i, nodes);
   }
 
-  force.initialize = function(_) {
-    nodes = _;
+  force.initialize = function(initNodes, numDimensions) {
+    nodes = initNodes;
+    nDim = numDimensions;
     initialize();
   };
 

--- a/src/collide.js
+++ b/src/collide.js
@@ -53,8 +53,14 @@ export default function(radius) {
       }
     }
 
-    function apply(treeNode, x0, arg1, arg2, arg3) {
-      var x1 = [arg1, arg2, arg3][nDim-1];
+    function apply(treeNode, arg1, arg2, arg3, arg4, arg5, arg6) {
+      var args = [arg1, arg2, arg3, arg4, arg5, arg6];
+      var x0 = args[0],
+          y0 = args[1],
+          z0 = args[2],
+          x1 = args[nDim],
+          y1 = args[nDim+1],
+          z1 = args[nDim+2];
 
       var data = treeNode.data, rj = treeNode.r, r = ri + rj;
       if (data) {

--- a/src/link.js
+++ b/src/link.js
@@ -19,6 +19,7 @@ export default function(links) {
       distance = constant(30),
       distances,
       nodes,
+      nDim,
       count,
       bias,
       iterations = 1;
@@ -31,17 +32,22 @@ export default function(links) {
 
   function force(alpha) {
     for (var k = 0, n = links.length; k < iterations; ++k) {
-      for (var i = 0, link, source, target, x, y, l, b; i < n; ++i) {
+      for (var i = 0, link, source, target, x = 0, y = 0, z = 0, l, b; i < n; ++i) {
         link = links[i], source = link.source, target = link.target;
         x = target.x + target.vx - source.x - source.vx || jiggle();
-        y = target.y + target.vy - source.y - source.vy || jiggle();
-        l = Math.sqrt(x * x + y * y);
+        if (nDim > 1) { y = target.y + target.vy - source.y - source.vy || jiggle(); }
+        if (nDim > 2) { z = target.z + target.vz - source.z - source.vz || jiggle(); }
+        l = Math.sqrt(x * x + y * y + z * z);
         l = (l - distances[i]) / l * alpha * strengths[i];
-        x *= l, y *= l;
+        x *= l, y *= l, z *= l;
+
         target.vx -= x * (b = bias[i]);
-        target.vy -= y * b;
+        if (nDim > 1) { target.vy -= y * b; }
+        if (nDim > 2) { target.vz -= z * b; }
+
         source.vx += x * (b = 1 - b);
-        source.vy += y * b;
+        if (nDim > 1) { source.vy += y * b; }
+        if (nDim > 2) { source.vz += z * b; }
       }
     }
   }
@@ -87,8 +93,9 @@ export default function(links) {
     }
   }
 
-  force.initialize = function(_) {
-    nodes = _;
+  force.initialize = function(initNodes, numDimensions) {
+    nodes = initNodes;
+    nDim = numDimensions;
     initialize();
   };
 

--- a/src/manyBody.js
+++ b/src/manyBody.js
@@ -64,16 +64,9 @@ export default function() {
     treeNode.value = strength;
   }
 
-  function apply(treeNode) {
-    var args = Array.prototype.slice.call(arguments);
-    if (nDim > 2) { args.pop(); }
-    if (nDim > 1) { args.pop(); }
-    var x2 = args.pop();
-    if (nDim > 2) { args.pop(); }
-    if (nDim > 1) { args.pop(); }
-    var x1 = args.pop();
-
+  function apply(treeNode, x1, arg1, arg2, arg3) {
     if (!treeNode.value) return true;
+    var x2 = [arg1, arg2, arg3][nDim-1];
 
     var x = treeNode.x - node.x,
         y = (nDim > 1 ? treeNode.y - node.y : 0),

--- a/src/manyBody.js
+++ b/src/manyBody.js
@@ -1,10 +1,13 @@
 import constant from "./constant";
 import jiggle from "./jiggle";
+import {binarytree} from "d3-binarytree";
 import {quadtree} from "d3-quadtree";
-import {x, y} from "./simulation";
+import {octree} from "d3-octree";
+import {x, y, z} from "./simulation";
 
 export default function() {
   var nodes,
+      nDim,
       node,
       alpha,
       strength = constant(-30),
@@ -14,7 +17,15 @@ export default function() {
       theta2 = 0.81;
 
   function force(_) {
-    var i, n = nodes.length, tree = quadtree(nodes, x, y).visitAfter(accumulate);
+    var i,
+        n = nodes.length,
+        tree =
+            (nDim === 1 ? binarytree(nodes, x)
+            :(nDim === 2 ? quadtree(nodes, x, y)
+            :(nDim === 3 ? octree(nodes, x, y, z)
+            :null
+        ))).visitAfter(accumulate);
+
     for (alpha = _, i = 0; i < n; ++i) node = nodes[i], tree.visit(apply);
   }
 
@@ -25,72 +36,88 @@ export default function() {
     for (i = 0; i < n; ++i) node = nodes[i], strengths[node.index] = +strength(node, i, nodes);
   }
 
-  function accumulate(quad) {
-    var strength = 0, q, c, x, y, i;
+  function accumulate(treeNode) {
+    var strength = 0, q, c, x, y, z, i;
 
-    // For internal nodes, accumulate forces from child quadrants.
-    if (quad.length) {
-      for (x = y = i = 0; i < 4; ++i) {
-        if ((q = quad[i]) && (c = q.value)) {
-          strength += c, x += c * q.x, y += c * q.y;
+    // For internal nodes, accumulate forces from children.
+    if (treeNode.length) {
+      for (x = y = z = i = 0; i < 4; ++i) {
+        if ((q = treeNode[i]) && (c = q.value)) {
+          strength += c, x += c * (q.x || 0), y += c * (q.y || 0), z += c * (q.z || 0);
         }
       }
-      quad.x = x / strength;
-      quad.y = y / strength;
+      treeNode.x = x / strength;
+      if (nDim > 1) { treeNode.y = y / strength; }
+      if (nDim > 2) { treeNode.z = z / strength; }
     }
 
-    // For leaf nodes, accumulate forces from coincident quadrants.
+    // For leaf nodes, accumulate forces from coincident nodes.
     else {
-      q = quad;
+      q = treeNode;
       q.x = q.data.x;
-      q.y = q.data.y;
+      if (nDim > 1) { q.y = q.data.y; }
+      if (nDim > 2) { q.z = q.data.z; }
       do strength += strengths[q.data.index];
       while (q = q.next);
     }
 
-    quad.value = strength;
+    treeNode.value = strength;
   }
 
-  function apply(quad, x1, _, x2) {
-    if (!quad.value) return true;
+  function apply(treeNode) {
+    var args = Array.prototype.slice.call(arguments);
+    if (nDim > 2) { args.pop(); }
+    if (nDim > 1) { args.pop(); }
+    var x2 = args.pop();
+    if (nDim > 2) { args.pop(); }
+    if (nDim > 1) { args.pop(); }
+    var x1 = args.pop();
 
-    var x = quad.x - node.x,
-        y = quad.y - node.y,
+    if (!treeNode.value) return true;
+
+    var x = treeNode.x - node.x,
+        y = (nDim > 1 ? treeNode.y - node.y : 0),
+        z = (nDim > 2 ? treeNode.z - node.z : 0),
         w = x2 - x1,
-        l = x * x + y * y;
+        l = x * x + y * y + z * z;
 
     // Apply the Barnes-Hut approximation if possible.
     // Limit forces for very close nodes; randomize direction if coincident.
     if (w * w / theta2 < l) {
       if (l < distanceMax2) {
         if (x === 0) x = jiggle(), l += x * x;
-        if (y === 0) y = jiggle(), l += y * y;
+        if (nDim > 1 && y === 0) y = jiggle(), l += y * y;
+        if (nDim > 2 && z === 0) z = jiggle(), l += z * z;
         if (l < distanceMin2) l = Math.sqrt(distanceMin2 * l);
-        node.vx += x * quad.value * alpha / l;
-        node.vy += y * quad.value * alpha / l;
+        node.vx += x * treeNode.value * alpha / l;
+        if (nDim > 1) { node.vy += y * treeNode.value * alpha / l; }
+        if (nDim > 2) { node.vz += z * treeNode.value * alpha / l; }
       }
       return true;
     }
 
     // Otherwise, process points directly.
-    else if (quad.length || l >= distanceMax2) return;
+    else if (treeNode.length || l >= distanceMax2) return;
 
     // Limit forces for very close nodes; randomize direction if coincident.
-    if (quad.data !== node || quad.next) {
+    if (treeNode.data !== node || treeNode.next) {
       if (x === 0) x = jiggle(), l += x * x;
-      if (y === 0) y = jiggle(), l += y * y;
+      if (nDim > 1 && y === 0) y = jiggle(), l += y * y;
+      if (nDim > 2 && z === 0) z = jiggle(), l += z * z;
       if (l < distanceMin2) l = Math.sqrt(distanceMin2 * l);
     }
 
-    do if (quad.data !== node) {
-      w = strengths[quad.data.index] * alpha / l;
+    do if (treeNode.data !== node) {
+      w = strengths[treeNode.data.index] * alpha / l;
       node.vx += x * w;
-      node.vy += y * w;
-    } while (quad = quad.next);
+      if (nDim > 1) { node.vy += y * w; }
+      if (nDim > 2) { node.vz += z * w; }
+    } while (treeNode = treeNode.next);
   }
 
-  force.initialize = function(_) {
-    nodes = _;
+  force.initialize = function(initNodes, numDimensions) {
+    nodes = initNodes;
+    nDim = numDimensions;
     initialize();
   };
 

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -17,7 +17,8 @@ export function z(d) {
 }
 
 var initialRadius = 10,
-    initialAngle = Math.PI * (3 - Math.sqrt(5));
+    initialAngleRoll = Math.PI * (3 - Math.sqrt(5)), // Golden angle
+    initialAngleYaw = Math.PI / 24; // Sequential
 
 export default function(nodes, numDimensions) {
   numDimensions = numDimensions || 2;
@@ -72,10 +73,12 @@ export default function(nodes, numDimensions) {
     for (var i = 0, n = nodes.length, node; i < n; ++i) {
       node = nodes[i], node.index = i;
       if (isNaN(node.x) || (nDim > 1 && isNaN(node.y)) || (nDim > 2 && isNaN(node.z))) {
-        var radius = initialRadius * Math.sqrt(i), angle = i * initialAngle;
-        node.x = radius * Math.cos(angle);
-        if (nDim > 1) { node.y = radius * Math.sin(angle); }
-        if (nDim > 2) { node.z = radius * Math.sin(angle); }
+        var radius = initialRadius * (nDim > 2 ? Math.cbrt(i) : (nDim > 1 ? Math.sqrt(i) : i)),
+          rollAngle = i * initialAngleRoll,
+          yawAngle = i * initialAngleYaw;
+        node.x = radius * Math.cos(rollAngle);
+        if (nDim > 1) { node.y = radius * Math.sin(rollAngle); }
+        if (nDim > 2) { node.z = radius * Math.sin(yawAngle); }
       }
       if (isNaN(node.vx) || (nDim > 1 && isNaN(node.vy)) || (nDim > 2 && isNaN(node.vz))) {
         node.vx = 0;

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -76,7 +76,7 @@ export default function(nodes, numDimensions) {
         var radius = initialRadius * (nDim > 2 ? Math.cbrt(i) : (nDim > 1 ? Math.sqrt(i) : i)),
           rollAngle = i * initialAngleRoll,
           yawAngle = i * initialAngleYaw;
-        node.x = radius * Math.cos(rollAngle);
+        node.x = radius * (nDim > 1 ? Math.cos(rollAngle) : 1);
         if (nDim > 1) { node.y = radius * Math.sin(rollAngle); }
         if (nDim > 2) { node.z = radius * Math.sin(yawAngle); }
       }

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -140,13 +140,12 @@ export default function(nodes, numDimensions) {
       return arguments.length > 1 ? ((_ == null ? forces.remove(name) : forces.set(name, initializeForce(_))), simulation) : forces.get(name);
     },
 
-    find: function(x, y, radius) {
-      return this.findClosest(radius, x, y);
-    },
-
-    findClosest: function(radius, x, y, z) {
-      y = y || 0,
-      z = z || 0;
+    find: function() {
+      var args = Array.prototype.slice.call(arguments);
+      var x = args.shift() || 0,
+          y = (nDim > 1 ? args.shift() : null) || 0,
+          z = (nDim > 2 ? args.shift() : null) || 0,
+          radius = args.shift() || Infinity;
 
       var i = 0,
           n = nodes.length,
@@ -157,8 +156,7 @@ export default function(nodes, numDimensions) {
           node,
           closest;
 
-      if (radius == null) radius = Infinity;
-      else radius *= radius;
+      radius *= radius;
 
       for (i = 0; i < n; ++i) {
         node = nodes[i];

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -22,7 +22,7 @@ var initialRadius = 10,
 export default function(nodes, numDimensions) {
   numDimensions = numDimensions || 2;
 
-  var dim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(numDimensions))),
+  var nDim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(numDimensions))),
       simulation,
       alpha = 1,
       alphaMin = 0.001,
@@ -57,11 +57,11 @@ export default function(nodes, numDimensions) {
       node = nodes[i];
       if (node.fx == null) node.x += node.vx *= velocityDecay;
       else node.x = node.fx, node.vx = 0;
-      if (dim > 1) {
+      if (nDim > 1) {
         if (node.fy == null) node.y += node.vy *= velocityDecay;
         else node.y = node.fy, node.vy = 0;
       }
-      if (dim > 2) {
+      if (nDim > 2) {
         if (node.fz == null) node.z += node.vz *= velocityDecay;
         else node.z = node.fz, node.vz = 0;
       }
@@ -71,22 +71,22 @@ export default function(nodes, numDimensions) {
   function initializeNodes() {
     for (var i = 0, n = nodes.length, node; i < n; ++i) {
       node = nodes[i], node.index = i;
-      if (isNaN(node.x) || (dim > 1 && isNaN(node.y)) || (dim > 2 && isNaN(node.z))) {
+      if (isNaN(node.x) || (nDim > 1 && isNaN(node.y)) || (nDim > 2 && isNaN(node.z))) {
         var radius = initialRadius * Math.sqrt(i), angle = i * initialAngle;
         node.x = radius * Math.cos(angle);
-        if (dim > 1) { node.y = radius * Math.sin(angle); }
-        if (dim > 2) { node.z = radius * Math.sin(angle); }
+        if (nDim > 1) { node.y = radius * Math.sin(angle); }
+        if (nDim > 2) { node.z = radius * Math.sin(angle); }
       }
-      if (isNaN(node.vx) || (dim > 1 && isNaN(node.vy)) || (dim > 2 && isNaN(node.vz))) {
+      if (isNaN(node.vx) || (nDim > 1 && isNaN(node.vy)) || (nDim > 2 && isNaN(node.vz))) {
         node.vx = 0;
-        if (dim > 1) { node.vy = 0; }
-        if (dim > 2) { node.vz = 0; }
+        if (nDim > 1) { node.vy = 0; }
+        if (nDim > 2) { node.vz = 0; }
       }
     }
   }
 
   function initializeForce(force) {
-    if (force.initialize) force.initialize(nodes);
+    if (force.initialize) force.initialize(nodes, nDim);
     return force;
   }
 
@@ -105,8 +105,8 @@ export default function(nodes, numDimensions) {
 
     numDimensions: function(_) {
       return arguments.length
-          ? (dim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(_))), initializeNodes(), forces.each(initializeForce), simulation)
-          : dim;
+          ? (nDim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(_))), initializeNodes(), forces.each(initializeForce), simulation)
+          : nDim;
     },
 
     nodes: function(_) {

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -108,7 +108,7 @@ export default function(nodes, numDimensions) {
 
     numDimensions: function(_) {
       return arguments.length
-          ? (nDim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(_))), initializeNodes(), forces.each(initializeForce), simulation)
+          ? (nDim = Math.min(MAX_DIMENSIONS, Math.max(1, Math.round(_))), forces.each(initializeForce), simulation)
           : nDim;
     },
 

--- a/src/z.js
+++ b/src/z.js
@@ -1,0 +1,41 @@
+import constant from "./constant";
+
+export default function(z) {
+  var strength = constant(0.1),
+      nodes,
+      strengths,
+      zz;
+
+  if (typeof z !== "function") z = constant(z == null ? 0 : +z);
+
+  function force(alpha) {
+    for (var i = 0, n = nodes.length, node; i < n; ++i) {
+      node = nodes[i], node.vz += (zz[i] - node.z) * strengths[i] * alpha;
+    }
+  }
+
+  function initialize() {
+    if (!nodes) return;
+    var i, n = nodes.length;
+    strengths = new Array(n);
+    zz = new Array(n);
+    for (i = 0; i < n; ++i) {
+      strengths[i] = isNaN(zz[i] = +z(nodes[i], i, nodes)) ? 0 : +strength(nodes[i], i, nodes);
+    }
+  }
+
+  force.initialize = function(_) {
+    nodes = _;
+    initialize();
+  };
+
+  force.strength = function(_) {
+    return arguments.length ? (strength = typeof _ === "function" ? _ : constant(+_), initialize(), force) : strength;
+  };
+
+  force.z = function(_) {
+    return arguments.length ? (z = typeof _ === "function" ? _ : constant(+_), initialize(), force) : z;
+  };
+
+  return force;
+}


### PR DESCRIPTION
I've upgraded D3-force to support other dimensions besides 2D, via the method `numDimensions()`, supporting the values [1,2,3] (default to 2). It should be fully backwards compatible with the present defaults.

Is there interest to include this functionality in core D3-force? Ideally it should also import the modules https://github.com/vasturiano/d3-binarytree and https://github.com/vasturiano/d3-octree.

This block highlights the new functionality: https://bl.ocks.org/vasturiano/f59675656258d3f490e9faa40828c0e7