### PR TITLE
Abs weighted average in manyBody barnes-hut coords

### DIFF
--- a/src/manyBody.js
+++ b/src/manyBody.js
@@ -26,17 +26,17 @@ export default function() {
   }
 
   function accumulate(quad) {
-    var strength = 0, q, c, x, y, i;
+    var strength = 0, q, c, sumC = 0, x, y, i;
 
     // For internal nodes, accumulate forces from child quadrants.
     if (quad.length) {
       for (x = y = i = 0; i < 4; ++i) {
-        if ((q = quad[i]) && (c = q.value)) {
-          strength += c, x += c * q.x, y += c * q.y;
+        if ((q = quad[i]) && (c = Math.abs(q.value))) {
+          strength += q.value, sumC += c, x += c * q.x, y += c * q.y;
         }
       }
-      quad.x = x / strength;
-      quad.y = y / strength;
+      quad.x = x / sumC;
+      quad.y = y / sumC;
     }
 
     // For leaf nodes, accumulate forces from coincident quadrants.


### PR DESCRIPTION
The quadrant coordinates for the Barnes-Hut approx in forceManyBody are calculated using a weighted average according to the child strengths. However, the current calc is not accounting for negative strengths which may throw off the `quad.x`/`quad.y` coords. Furthermore the issue is aggravated when combining positive and negative strengths, which will result in a reduced aggregated strength (due to cancellation), leading to very high values of `x` and `y`.

I came across the issue when noticing combined nodes with positive and negative strengths having a much lower force intensity, due to the quadrant centers being much more distant.

This patch abs the weights in the average to fix the issue.