### PR TITLE
Remove `i` reinitialization

### DIFF
--- a/src/x.js
+++ b/src/x.js
@@ -16,10 +16,10 @@ export default function(x) {
 
   function initialize() {
     if (!nodes) return;
-    var i, n = nodes.length;
+    var n = nodes.length;
     strengths = new Array(n);
     xz = new Array(n);
-    for (i = 0; i < n; ++i) {
+    for (var i = 0; i < n; ++i) {
       strengths[i] = isNaN(xz[i] = +x(nodes[i], i, nodes)) ? 0 : +strength(nodes[i], i, nodes);
     }
   }


### PR DESCRIPTION
the i value is overwritten in this case the moment the code steps into the for loop, making the default assignment and declaration of i misleading and unneeded.