### PR TITLE
Initialize fixed nodes from f* attributes

### DIFF
--- a/src/simulation.js
+++ b/src/simulation.js
@@ -56,6 +56,8 @@ export default function(nodes) {
   function initializeNodes() {
     for (var i = 0, n = nodes.length, node; i < n; ++i) {
       node = nodes[i], node.index = i;
+      if (!isNaN(node.fx)) node.x = node.fx;
+      if (!isNaN(node.fy)) node.y = node.fy;
       if (isNaN(node.x) || isNaN(node.y)) {
         var radius = initialRadius * Math.sqrt(i), angle = i * initialAngle;
         node.x = radius * Math.cos(angle);


### PR DESCRIPTION
Fix for #123. It's a good idea to initialize fixed nodes from their `fx`, `fy` attrbutes, if set.