### PR TITLE
Adds bugs field

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "type": "git",
     "url": "https://github.com/d3/d3-force.git"
   },
+  "bugs": {
+    "url": "https://d3js.org/d3-force/issues"
+  },
   "scripts": {
     "pretest": "rollup -c",
     "test": "tape 'test/**/*-test.js' && eslint src",


### PR DESCRIPTION
There is no [bugs field](https://docs.npmjs.com/files/package.json#bugs) in the `package.json`. I've added it to make it easier to find.