### PR TITLE
indicate node is missing in missing node error

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -7,7 +7,7 @@ function index(d) {
 
 function find(nodeById, nodeId) {
   var node = nodeById.get(nodeId);
-  if (!node) throw new Error("missing: " + nodeId);
+  if (!node) throw new Error("missing node: " + nodeId);
   return node;
 }
 

--- a/src/link.js
+++ b/src/link.js
@@ -7,7 +7,7 @@ function index(d) {
 
 function find(nodeById, nodeId) {
   var node = nodeById.get(nodeId);
-  if (!node) throw new Error("missing node: " + nodeId);
+  if (!node) throw new Error("node not found: " + nodeId);
   return node;
 }
 


### PR DESCRIPTION
this avoids the difficult to debug message `missing: undefined` that appears when a nodeId is undefined.