### PR TITLE
add forceExtent

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ If *x* is specified, sets the *x*-coordinate of the centering position to the sp
 
 If *y* is specified, sets the *y*-coordinate of the centering position to the specified number and returns this force. If *y* is not specified, returns the current *y*-coordinate, which defaults to zero.
 
+<a name="forceExtent" href="#forceExtent">#</a> d3.<b>forceExtent</b>([<i>extent</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/extent.js#L1 "Source")
+
+Creates a new extent force with the specified extent as [[xmin, ymin], [xmax, ymax]]. If *extent* is not specified, its defaults to [⟨0,0⟩, ⟨960,500⟩]. This force maintains the nodes inside the extent, taking into account their radius (if the property is set).
+
+<a name="extent_extent" href="#extent_extent">#</a> <i>extent</i>.<b>extent</b>([<i>extent</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/extent.js#L1 "Source")
+
+If *extent* is specified, sets the extent and returns this force. If *extent* is not specified, returns the current extent.
+
 #### Collision
 
 The collision force treats nodes as circles with a given [radius](#collide_radius), rather than points, and prevents nodes from overlapping. More formally, two nodes *a* and *b* are separated so that the distance between *a* and *b* is at least *radius*(*a*) + *radius*(*b*). To reduce jitter, this is by default a “soft” constraint with a configurable [strength](#collide_strength) and [iteration count](#collide_iterations).

--- a/src/extent.js
+++ b/src/extent.js
@@ -1,0 +1,25 @@
+export default function(extent) {
+  var nodes;
+
+  if (extent === undefined) extent = [[0, 0], [960, 500]];
+
+  function force() {
+    for (var i = 0; i < nodes.length; ++i) {
+      var node = nodes[i], r = node.radius || 0;
+      node.x = clamp(node.x, extent[0][0] - r, extent[1][0] + r);
+      node.y = clamp(node.y, extent[0][1] - r, extent[1][0] + r);
+    }
+  }
+
+  force.initialize = function(_) { nodes = _; };
+
+  force.extent = function(_) {
+      return arguments.length ? (extent = _, force) : extent;
+  };
+
+  return force;
+}
+
+function clamp(x, min, max) {
+  return Math.max(min, Math.min(max, x));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export {default as forceCenter} from "./center.js";
 export {default as forceCollide} from "./collide.js";
+export {default as forceExtent} from "./extent.js";
 export {default as forceLink} from "./link.js";
 export {default as forceManyBody} from "./manyBody.js";
 export {default as forceRadial} from "./radial.js";


### PR DESCRIPTION
fixes #89

note that the extent's definition in this PR is [[*xmin*, *ymin*], [*xmax*, *ymax*]], more in line with, for example zoom.extent. Defaults to [[0,0], [960,500]].

by @gka