### PR TITLE
prepare deps for d3v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,11 +425,11 @@ function y() {
 
 The *y*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *y*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *y*, and not on every application of the force.
 
-<a name="forceRadial" href="#forceRadial">#</a> d3.<b>forceRadial</b>(<i>radius</i>[, <i>x</i>][, <i>y</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
+<a name="forceRadial" href="#forceRadial">#</a> d3.<b>forceRadial</b>(<i>radius</i>[, <i>x</i>][, <i>y</i>][, <i>angle</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
 
 [<img alt="Radial Force" src="https://raw.githubusercontent.com/d3/d3-force/master/img/radial.png" width="420" height="219">](https://bl.ocks.org/mbostock/cd98bf52e9067e26945edd95e8cf6ef9)
 
-Creates a new positioning force towards a circle of the specified [*radius*](#radial_radius) centered at ⟨[*x*](#radial_x),[*y*](#radial_y)⟩. If *x* and *y* are not specified, they default to ⟨0,0⟩.
+Creates a new positioning force towards a circle of the specified [*radius*](#radial_radius) centered at ⟨[*x*](#radial_x),[*y*](#radial_y)⟩, and with a preferred [*angle*](#radial_angle). If *x* and *y* are not specified, they default to ⟨0,0⟩. If *radius* or *angle* are not specified (or null), they are ignored.
 
 <a name="radial_strength" href="#radial_strength">#</a> <i>radial</i>.<b>strength</b>([<i>strength</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
 
@@ -447,7 +447,7 @@ The strength accessor is invoked for each [node](#simulation_nodes) in the simul
 
 <a name="radial_radius" href="#radial_radius">#</a> <i>radial</i>.<b>radius</b>([<i>radius</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
 
-If *radius* is specified, sets the circle *radius* to the specified number or function, re-evaluates the *radius* accessor for each node, and returns this force. If *radius* is not specified, returns the current *radius* accessor.
+If *radius* is specified, sets the circle *radius* to the specified number or function, re-evaluates the *radius* accessor for each node, and returns this force. If *radius* is not specified, returns the current *radius* accessor. If *angle* is null, the force ignores the radius (see [*radial*.angle](#radial_angle)).
 
 The *radius* accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target radius of each node is only recomputed when the force is initialized or when this method is called with a new *radius*, and not on every application of the force.
 
@@ -474,4 +474,10 @@ function y() {
 ```
 
 The *y*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *y*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *y*, and not on every application of the force.
+
+<a name="radial_angle" href="#radial_angle">#</a> <i>radial</i>.<b>angle</b>([<i>angle</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
+
+If *angle* is specified, sets the preferred *angle* to the specified number or function, re-evaluates the *angle* accessor for each node, and returns this force. If *angle* is not specified, returns the current *angle* accessor. If *angle* is null, the force ignores the preferred angle.
+
+The *angle* accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target angle of each node is only recomputed when the force is initialized or when this method is called with a new *angle*, and not on every application of the force.
 

--- a/README.md
+++ b/README.md
@@ -453,8 +453,25 @@ The *radius* accessor is invoked for each [node](#simulation_nodes) in the simul
 
 <a name="radial_x" href="#radial_x">#</a> <i>radial</i>.<b>x</b>([<i>x</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
 
-If *x* is specified, sets the *x*-coordinate of the circle center to the specified number and returns this force. If *x* is not specified, returns the current *x*-coordinate of the center, which defaults to zero.
+If *x* is specified, sets the *x*-coordinate accessor to the specified number or function, re-evaluates the *x*-accessor for each node, and returns this force. If *x* is not specified, returns the current *x*-accessor, which defaults to:
+
+```js
+function x() {
+  return 0;
+}
+```
+
+The *x*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *x*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *x*, and not on every application of the force.
 
 <a name="radial_y" href="#radial_y">#</a> <i>radial</i>.<b>y</b>([<i>y</i>]) [<>](https://github.com/d3/d3-force/blob/master/src/radial.js "Source")
 
-If *y* is specified, sets the *y*-coordinate of the circle center to the specified number and returns this force. If *y* is not specified, returns the current *y*-coordinate of the center, which defaults to zero.
+If *y* is specified, sets the *y*-coordinate accessor to the specified number or function, re-evaluates the *y*-accessor for each node, and returns this force. If *y* is not specified, returns the current *y*-accessor, which defaults to:
+
+```js
+function y() {
+  return 0;
+}
+```
+
+The *y*-accessor is invoked for each [node](#simulation_nodes) in the simulation, being passed the *node* and its zero-based *index*. The resulting number is then stored internally, such that the target *y*-coordinate of each node is only recomputed when the force is initialized or when this method is called with a new *y*, and not on every application of the force.
+

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "dist/**/*.js"
   ],
   "dependencies": {
-    "d3-dispatch": "1",
-    "d3-quadtree": "1",
-    "d3-timer": "1"
+    "d3-dispatch": ">=2.0.0-rc.1",
+    "d3-quadtree": ">=2.0.0-rc.1",
+    "d3-timer": ">=2.0.0-rc.1"
   },
   "sideEffects": false,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "d3-force",
-  "version": "2.0.1",
+  "version": "2.1.0-rc.1",
+  "publishConfig": {
+    "tag": "next"
+  },
   "description": "Force-directed graph layout using velocity Verlet integration.",
   "keywords": [
     "d3",

--- a/src/center.js
+++ b/src/center.js
@@ -1,10 +1,10 @@
 export default function(x, y) {
-  var nodes;
+  var nodes, strength = 0.05;
 
   if (x == null) x = 0;
   if (y == null) y = 0;
 
-  function force() {
+  function force(alpha) {
     var i,
         n = nodes.length,
         node,
@@ -15,8 +15,10 @@ export default function(x, y) {
       node = nodes[i], sx += node.x, sy += node.y;
     }
 
-    for (sx = sx / n - x, sy = sy / n - y, i = 0; i < n; ++i) {
-      node = nodes[i], node.x -= sx, node.y -= sy;
+    sx = (sx / n - x) * alpha * strength;
+    sy = (sy / n - y) * alpha * strength;
+    for (i = 0; i < n; ++i) {
+      node = nodes[i], node.vx -= sx, node.vy -= sy;
     }
   }
 

--- a/src/jiggle.js
+++ b/src/jiggle.js
@@ -4,6 +4,6 @@ const a = 1664525,
       m = 4294967296;
 let s = 1;
 export default function(seed) {
-  if (seed) s = Math.abs(m * seed);
+  if (seed) s = Math.abs(a * seed);
   return ((s = (a * s + c) % m) / m - 0.5) * 1e-6;
 }

--- a/src/jiggle.js
+++ b/src/jiggle.js
@@ -4,5 +4,6 @@ const a = 1664525,
       m = 4294967296;
 let s = 1;
 export default function(seed) {
-  return (s = seed || (a * s + c) % m) / m * 1e-6;
+  if (seed) s = Math.abs(m * seed);
+  return ((s = (a * s + c) % m) / m - 0.5) * 1e-6;
 }

--- a/src/jiggle.js
+++ b/src/jiggle.js
@@ -1,3 +1,8 @@
-export default function() {
-  return (Math.random() - 0.5) * 1e-6;
+// https://en.wikipedia.org/wiki/Linear_congruential_generator#Parameters_in_common_use
+const a = 1664525,
+      c = 1013904223,
+      m = 4294967296;
+let s = 1;
+export default function(seed) {
+  return (s = seed || (a * s + c) % m) / m * 1e-6;
 }

--- a/src/math.js
+++ b/src/math.js
@@ -1,0 +1,2 @@
+export var pi = Math.PI;
+export var radians = pi / 180;

--- a/src/radial.js
+++ b/src/radial.js
@@ -4,17 +4,19 @@ export default function(radius, x, y) {
   var nodes,
       strength = constant(0.1),
       strengths,
-      radiuses;
+      radiuses,
+      xs,
+      ys;
 
   if (typeof radius !== "function") radius = constant(+radius);
-  if (x == null) x = 0;
-  if (y == null) y = 0;
+  if (typeof x !== "function") x = constant(x == null ? 0 : +x);
+  if (typeof y !== "function") y = constant(y == null ? 0 : +y);
 
   function force(alpha) {
     for (var i = 0, n = nodes.length; i < n; ++i) {
       var node = nodes[i],
-          dx = node.x - x || 1e-6,
-          dy = node.y - y || 1e-6,
+          dx = node.x - xs[i] || 1e-6,
+          dy = node.y - ys[i] || 1e-6,
           r = Math.sqrt(dx * dx + dy * dy),
           k = (radiuses[i] - r) * strengths[i] * alpha / r;
       node.vx += dx * k;
@@ -27,8 +29,12 @@ export default function(radius, x, y) {
     var i, n = nodes.length;
     strengths = new Array(n);
     radiuses = new Array(n);
+    xs = new Array(n);
+    ys = new Array(n);
     for (i = 0; i < n; ++i) {
       radiuses[i] = +radius(nodes[i], i, nodes);
+      xs[i] = +x(nodes[i], i, nodes);
+      ys[i] = +y(nodes[i], i, nodes);
       strengths[i] = isNaN(radiuses[i]) ? 0 : +strength(nodes[i], i, nodes);
     }
   }
@@ -46,11 +52,11 @@ export default function(radius, x, y) {
   };
 
   force.x = function(_) {
-    return arguments.length ? (x = +_, force) : x;
+    return arguments.length ? (x = typeof _ === "function" ? _ : constant(+_), initialize(), force) : x;
   };
 
   force.y = function(_) {
-    return arguments.length ? (y = +_, force) : y;
+    return arguments.length ? (y = typeof _ === "function" ? _ : constant(+_), initialize(), force) : y;
   };
 
   return force;

--- a/src/radial.js
+++ b/src/radial.js
@@ -1,26 +1,52 @@
 import constant from "./constant.js";
+import {radians} from "./math.js";
 
-export default function(radius, x, y) {
+function value(x) {
+  if (typeof x === "function") return x;
+  if (x === null || x === undefined || isNaN(x = +x)) return;
+  return constant(x);
+}
+
+export default function(radius, x, y, angle) {
   var nodes,
       strength = constant(0.1),
       strengths,
-      radiuses,
+      radii,
       xs,
-      ys;
+      ys,
+      angles;
 
-  if (typeof radius !== "function") radius = constant(+radius);
-  if (typeof x !== "function") x = constant(x == null ? 0 : +x);
-  if (typeof y !== "function") y = constant(y == null ? 0 : +y);
+  radius = value(radius);
+  x = value(x) || constant(0);
+  y = value(y) || constant(0);
+  angle = value(angle);
 
   function force(alpha) {
     for (var i = 0, n = nodes.length; i < n; ++i) {
       var node = nodes[i],
           dx = node.x - xs[i] || 1e-6,
           dy = node.y - ys[i] || 1e-6,
-          r = Math.sqrt(dx * dx + dy * dy),
-          k = (radiuses[i] - r) * strengths[i] * alpha / r;
-      node.vx += dx * k;
-      node.vy += dy * k;
+          r = Math.sqrt(dx * dx + dy * dy);
+
+      if (radius) {
+        var k = ((radii[i] - r) * strengths[i] * alpha) / r;
+        node.vx += dx * k;
+        node.vy += dy * k;
+      }
+
+      if (angle) {
+        var a = Math.atan2(dy, dx),
+          diff = angles[i] - a,
+          q = r * Math.sin(diff) * (strengths[i] * alpha);
+
+        // the factor below augments the "unease" for points that are opposite
+        // the correct direction: in that case, though sin(diff) is small,
+        // tan(diff/2) is very high
+        q *= Math.hypot(1, Math.tan(diff / 2));
+
+        node.vx += -q * Math.sin(a);
+        node.vy += q * Math.cos(a);
+      }
     }
   }
 
@@ -28,14 +54,16 @@ export default function(radius, x, y) {
     if (!nodes) return;
     var i, n = nodes.length;
     strengths = new Array(n);
-    radiuses = new Array(n);
+    radii = new Array(n);
     xs = new Array(n);
     ys = new Array(n);
+    angles = new Array(n);
     for (i = 0; i < n; ++i) {
-      radiuses[i] = +radius(nodes[i], i, nodes);
+      if (radius) radii[i] = +radius(nodes[i], i, nodes);
       xs[i] = +x(nodes[i], i, nodes);
       ys[i] = +y(nodes[i], i, nodes);
-      strengths[i] = isNaN(radiuses[i]) ? 0 : +strength(nodes[i], i, nodes);
+      if (angle) angles[i] = +angle(nodes[i], i, nodes) * radians;
+      strengths[i] = isNaN(radii[i]) ? 0 : +strength(nodes[i], i, nodes);
     }
   }
 
@@ -44,19 +72,23 @@ export default function(radius, x, y) {
   };
 
   force.strength = function(_) {
-    return arguments.length ? (strength = typeof _ === "function" ? _ : constant(+_), initialize(), force) : strength;
+    return arguments.length ? (strength = value(_) || constant(1), initialize(), force) : strength;
   };
 
   force.radius = function(_) {
-    return arguments.length ? (radius = typeof _ === "function" ? _ : constant(+_), initialize(), force) : radius;
+    return arguments.length ? (radius = value(_), initialize(), force) : radius;
   };
 
   force.x = function(_) {
-    return arguments.length ? (x = typeof _ === "function" ? _ : constant(+_), initialize(), force) : x;
+    return arguments.length ? (x = value(_) || constant(0), initialize(), force) : x;
   };
 
   force.y = function(_) {
-    return arguments.length ? (y = typeof _ === "function" ? _ : constant(+_), initialize(), force) : y;
+    return arguments.length ? (y = value(_) || constant(0), initialize(), force) : y;
+  };
+
+force.angle = function(_) {
+    return arguments.length ? (angle = value(_), initialize(), force) : y;
   };
 
   return force;

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -21,6 +21,7 @@ export default function(nodes) {
       velocityDecay = 0.6,
       forces = new Map(),
       stepper = timer(step),
+      started = stepper.stop() || 0,
       event = dispatch("tick", "end");
 
   if (nodes == null) nodes = [];
@@ -144,7 +145,9 @@ export default function(nodes) {
     },
 
     on: function(name, _) {
-      return arguments.length > 1 ? (event.on(name, _), simulation) : event.on(name);
+      return arguments.length > 1
+        ? (event.on(name, _), started++ || stepper.restart(step), simulation)
+        : event.on(name);
     }
   };
 }

--- a/test/center-test.js
+++ b/test/center-test.js
@@ -1,0 +1,27 @@
+var tape = require("tape"),
+    force = require("../");
+
+require("./nodeEqual.js");
+
+tape("forceCenter repositions nodes", function(test) {
+  const center = force.forceCenter(0, 0);
+  const f = force.forceSimulation().force("center", center).stop();
+  const a = { x: 100, y: 0 }, b = { x: 200, y: 0 }, c = { x: 300, y: 0 };
+  f.nodes([a, b, c]);
+  f.tick();
+  test.nodeEqual(a, { index: 0, x: -100, y: 0, vy: 0, vx: 0 });
+  test.nodeEqual(b, { index: 1, x: 0, y: 0, vy: 0, vx: 0 });
+  test.nodeEqual(c, { index: 2, x: 100, y: 0, vy: 0, vx: 0 });
+  test.end();
+});
+
+
+tape("forceCenter respects fixed positions", function(test) {
+  const center = force.forceCenter();
+  const f = force.forceSimulation().force("center", center).stop();
+  const a = { fx: 0, fy:0 }, b = {}, c = {};
+  f.nodes([a, b, c]);
+  f.tick();
+  test.nodeEqual(a, { fx: 0, fy: 0, index: 0, x: 0, y: 0, vy: 0, vx: 0 });
+  test.end();
+});

--- a/test/center-test.js
+++ b/test/center-test.js
@@ -8,7 +8,7 @@ tape("forceCenter repositions nodes", function(test) {
   const f = force.forceSimulation().force("center", center).stop();
   const a = { x: 100, y: 0 }, b = { x: 200, y: 0 }, c = { x: 300, y: 0 };
   f.nodes([a, b, c]);
-  f.tick();
+  f.alphaDecay(0).tick(250);
   test.nodeEqual(a, { index: 0, x: -100, y: 0, vy: 0, vx: 0 });
   test.nodeEqual(b, { index: 1, x: 0, y: 0, vy: 0, vx: 0 });
   test.nodeEqual(c, { index: 2, x: 100, y: 0, vy: 0, vx: 0 });

--- a/test/collide-test.js
+++ b/test/collide-test.js
@@ -1,0 +1,48 @@
+var tape = require("tape"),
+    force = require("../");
+
+require("./nodeEqual.js");
+
+tape("forceCollide collides nodes", function(test) {
+  const collide = force.forceCollide(1);
+  const f = force.forceSimulation().force("collide", collide).stop();
+  const a = {}, b = {}, c = {};
+  f.nodes([a, b, c]);
+  f.tick(10);
+  test.nodeEqual(a, { index: 0, x: 7.0710678118654755, y: 0, vy: 0, vx: 0 });
+  test.nodeEqual(b, { index: 1, x: -9.03088751750192, y: 8.27303273571596, vy: 0, vx: 0 });
+  test.nodeEqual(c, { index: 2, x: 1.3823220809823638, y: -15.750847141167634, vy: 0, vx: 0 });
+  collide.radius(100);
+  f.tick(10);
+  test.nodeEqual(a,  { index: 0, x: 174.08616723117228, y: 66.51743051995625, vy: 0.26976816231064354, vx: 0.677346615710878 });
+  test.nodeEqual(b, { index: 1, x: -139.73606544743998, y: 95.69860503079263, vy: 0.3545632444404687, vx: -0.5300880593105067 });
+  test.nodeEqual(c, { index: 2, x: -34.9275994083864, y: -169.69384995620052, vy: -0.6243314067511122, vx: -0.1472585564003713 });
+  test.end();
+});
+
+
+tape("forceCollide respects fixed positions", function(test) {
+  const collide = force.forceCollide(1);
+  const f = force.forceSimulation().force("collide", collide).stop();
+  const a = { fx: 0, fy:0 }, b = {}, c = {};
+  f.nodes([a, b, c]);
+  f.tick(10);
+  test.nodeEqual(a, { fx: 0, fy: 0, index: 0, x: 0, y: 0, vy: 0, vx: 0 });
+  collide.radius(100);
+  f.tick(10);
+  test.nodeEqual(a, { fx: 0, fy: 0, index: 0, x: 0, y: 0, vy: 0, vx: 0 });
+  test.end();
+});
+
+tape("forceCollide jiggles equal positions", function(test) {
+  const collide = force.forceCollide(1);
+  const f = force.forceSimulation().force("collide", collide).stop();
+  const a = { x: 0, y:0 }, b = { x:0, y: 0 };
+  f.nodes([a, b]);
+  f.tick();
+  test.assert(a.x !== b.x);
+  test.assert(a.y !== b.y);
+  test.equal(a.vx, -b.vx);
+  test.equal(a.vy, -b.vy);
+  test.end();
+});

--- a/test/find-test.js
+++ b/test/find-test.js
@@ -1,0 +1,24 @@
+var tape = require("tape"),
+    force = require("../");
+
+require("./nodeEqual.js");
+
+tape("simulation.find finds a node", function(test) {
+  const f = force.forceSimulation().stop();
+  const a = { x: 5, y: 0 }, b = { x: 10, y: 16 }, c = { x: -10, y: -4};
+  f.nodes([a, b, c]);
+  test.equal(f.find(0, 0), a);
+  test.equal(f.find(0, 20), b);
+  test.end();
+});
+
+tape("simulation.find(x, y, radius) finds a node within radius", function(test) {
+  const f = force.forceSimulation().stop();
+  const a = { x: 5, y: 0 }, b = { x: 10, y: 16 }, c = { x: -10, y: -4};
+  f.nodes([a, b, c]);
+  test.equal(f.find(0, 0), a);
+  test.equal(f.find(0, 0, 1), undefined);
+  test.equal(f.find(0, 20), b);
+  test.end();
+});
+

--- a/test/nodeEqual.js
+++ b/test/nodeEqual.js
@@ -1,0 +1,23 @@
+var tape = require("tape");
+
+tape.Test.prototype.nodeEqual = nodeEqual;
+
+function nodeEqual(actual, expected, delta) {
+  delta = delta || 1e-6;
+  this._assert(nodeEqual(actual, expected, delta), {
+    message: "should be similar",
+    operator: "nodeEqual",
+    actual: actual,
+    expected: expected
+  });
+  
+  function nodeEqual(actual, expected, delta) {
+    return actual.index == expected.index
+        && Math.abs(actual.x - expected.x) < delta
+        && Math.abs(actual.vx - expected.vx) < delta
+        && Math.abs(actual.y - expected.y) < delta
+        && Math.abs(actual.vy - expected.vy) < delta
+        && !(Math.abs(actual.fx - expected.fx) > delta)
+        && !(Math.abs(actual.fy - expected.fy) > delta);
+  }
+}

--- a/test/simulation-test.js
+++ b/test/simulation-test.js
@@ -1,0 +1,21 @@
+var tape = require("tape"),
+    force = require("../");
+
+require("./nodeEqual.js");
+
+tape("forceSimulation() returns a simulation", function(test) {
+  const f = force.forceSimulation().stop();
+  test.deepEqual(Object.keys(f).sort(), [ 'alpha', 'alphaDecay', 'alphaMin', 'alphaTarget', 'find', 'force', 'nodes', 'on', 'restart', 'stop', 'tick', 'velocityDecay' ]);
+  test.end();
+});
+
+tape("simulation.nodes(nodes) initializes a simulation with indices & phyllotaxis positions, 0 speed", function(test) {
+  const f = force.forceSimulation().stop();
+  const a = {}, b = {}, c = {};
+  f.nodes([a, b, c]);
+  test.nodeEqual(a, { index: 0, x: 7.0710678118654755, y: 0, vy: 0, vx: 0 });
+  test.nodeEqual(b, { index: 1, x: -9.03088751750192, y: 8.27303273571596, vy: 0, vx: 0 });
+  test.nodeEqual(c, { index: 2, x: 1.3823220809823638, y: -15.750847141167634, vy: 0, vx: 0 });
+  test.end();
+});
+

--- a/test/x-test.js
+++ b/test/x-test.js
@@ -1,0 +1,84 @@
+var tape = require("tape"),
+    force = require("../");
+
+require("./nodeEqual.js");
+
+tape("forceX centers nodes", function(test) {
+  const x = force.forceX(200);
+  const f = force.forceSimulation().force("x", x).stop();
+  const a = { x: 100, y: 0 }, b = { x: 200, y: 0 }, c = { x: 300, y: 0 };
+  f.nodes([a, b, c]);
+  f.tick(30);
+  test.assert(a.x > 190);
+  test.assert(a.vx > 0);
+  test.equal(b.x, 200);
+  test.equal(b.vx, 0);
+  test.assert(c.x < 210);
+  test.assert(c.vx < 0);
+  test.end();
+});
+
+tape("forceY centers nodes", function(test) {
+  const y = force.forceY(200);
+  const f = force.forceSimulation().force("y", y).stop();
+  const a = { y: 100, x: 0 }, b = { y: 200, x: 0 }, c = { y: 300, x: 0 };
+  f.nodes([a, b, c]);
+  f.tick(30);
+  test.assert(a.y > 190);
+  test.assert(a.vy > 0);
+  test.equal(b.y, 200);
+  test.equal(b.vy, 0);
+  test.assert(c.y < 210);
+  test.assert(c.vy < 0);
+  test.end();
+});
+
+tape("forceX respects fixed positions", function(test) {
+  const x = force.forceX(200);
+  const f = force.forceSimulation().force("x", x).stop();
+  const a = { fx: 0, fy:0 }, b = {}, c = {};
+  f.nodes([a, b, c]);
+  f.tick();
+  test.nodeEqual(a, { fx: 0, fy: 0, index: 0, x: 0, y: 0, vy: 0, vx: 0 });
+  test.end();
+});
+
+tape("forceY respects fixed positions", function(test) {
+  const y = force.forceX(200);
+  const f = force.forceSimulation().force("y", y).stop();
+  const a = { fx: 0, fy:0 }, b = {}, c = {};
+  f.nodes([a, b, c]);
+  f.tick();
+  test.nodeEqual(a, { fx: 0, fy: 0, index: 0, x: 0, y: 0, vy: 0, vx: 0 });
+  test.end();
+});
+
+tape("forceX.x() accessor", function(test) {
+  const x = force.forceX().x(d => d.x0);
+  const f = force.forceSimulation().force("x", x).stop();
+  const a = { x: 100, y: 0, x0: 300 }, b = { x: 200, y: 0, x0: 200 }, c = { x: 300, y: 0, x0: 100 };
+  f.nodes([a, b, c]);
+  f.tick(30);
+  test.assert(a.x > 290);
+  test.assert(a.vx > 0);
+  test.equal(b.x, 200);
+  test.equal(b.vx, 0);
+  test.assert(c.x < 110);
+  test.assert(c.vx < 0);
+  test.end();
+});
+
+tape("forceY.y() accessor", function(test) {
+  const y = force.forceY().y(d => d.y0);
+  const f = force.forceSimulation().force("y", y).stop();
+  const a = { y: 100, x: 0, y0: 300 }, b = { y: 200, x: 0, y0: 200 }, c = { y: 300, x: 0, y0: 100 };
+  f.nodes([a, b, c]);
+  f.tick(30);
+  test.assert(a.y > 290);
+  test.assert(a.vy > 0);
+  test.equal(b.y, 200);
+  test.equal(b.vy, 0);
+  test.assert(c.y < 110);
+  test.assert(c.vy < 0);
+  test.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,20 +169,20 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-d3-dispatch@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.5.tgz#e25c10a186517cd6c82dd19ea018f07e01e39015"
-  integrity sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g==
+d3-dispatch@>=2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0-rc.1.tgz#cb7a29779b4dd4241ccef5b8a19f46a5e727f47b"
+  integrity sha512-JRzTbYPZ1GDu+eGZPOVyyhveu49PEL3msPVXBFEUDk0xCqhX7Eu2tCVcl+1gculBCkj6LEW2f725QmxWVsOPaA==
 
-d3-quadtree@1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.6.tgz#d1ab2a95a7f27bbde88582c94166f6ae35f32056"
-  integrity sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA==
+d3-quadtree@>=2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-2.0.0-rc.1.tgz#afc76b7ca3f63c3e0cb88fc246b30276beab0623"
+  integrity sha512-rt2PaorxXzxZYHw1nSM82nJjIj91VU3/r40LPNBGqIhRXlTuAlgspOH8/w85OOCqxSsV0c1qKwbzYIu/8bwD7A==
 
-d3-timer@1:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.9.tgz#f7bb8c0d597d792ff7131e1c24a36dd471a471ba"
-  integrity sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg==
+d3-timer@>=2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0-rc.1.tgz#8afc777810198f28d9b2ac1ef8765b767ce4bc22"
+  integrity sha512-Kfi4LnjFC1t1MnnjCrHh3TyQIJr9/mMjmjeTFYwG364CtTKtv8snI/juT5zoiCCsMwrxdzwrM7Kmpj24p/AClw==
 
 debug@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
- [x] add deterministic prng in the forceCollide "jiggle" (#160)
- [x] only start the simulation when someone is listening (fixes #45)
- [x] make forceCenter less aggressive  (fixes #81)
- [x] tests (#17) 
- [x] add forceRadial x, y and angle accessors? (#167)

Note: because of the breaking changes in #81 (which impacts #17), #167 (and partly #45) this branch is "maximalist", and should be published as `d3-force@3`

The alternative option is to have a minimalist PR with almost no code change (ie only https://github.com/d3/d3-force/pull/171/commits/f429ab1582d397a5c6bad45a6c5e4bde91882a07 and #160), that we can keep as v2.

