### PR TITLE
Let and Const in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you use NPM, `npm install d3-force`. Otherwise, download the [latest release]
 <script src="https://d3js.org/d3-force.v2.min.js"></script>
 <script>
 
-var simulation = d3.forceSimulation(nodes);
+const simulation = d3.forceSimulation(nodes);
 
 </script>
 ```
@@ -112,7 +112,7 @@ If *decay* is specified, sets the velocity decay factor to the specified number 
 If *force* is specified, assigns the [force](#forces) for the specified *name* and returns this simulation. If *force* is not specified, returns the force with the specified name, or undefined if there is no such force. (By default, new simulations have no forces.) For example, to create a new simulation to layout a graph, you might say:
 
 ```js
-var simulation = d3.forceSimulation(nodes)
+const simulation = d3.forceSimulation(nodes)
     .force("charge", d3.forceManyBody())
     .force("link", d3.forceLink(links))
     .force("center", d3.forceCenter());
@@ -151,7 +151,7 @@ A *force* is simply a function that modifies nodes’ positions or velocities; i
 
 ```js
 function force(alpha) {
-  for (var i = 0, n = nodes.length, node, k = alpha * 0.1; i < n; ++i) {
+  for (let i = 0, n = nodes.length, node, k = alpha * 0.1; i < n; ++i) {
     node = nodes[i];
     node.vx -= node.x * k;
     node.vy -= node.y * k;
@@ -264,13 +264,13 @@ function id(d) {
 The default id accessor allows each link’s source and target to be specified as a zero-based index into the [nodes](#simulation_nodes) array. For example:
 
 ```js
-var nodes = [
+const nodes = [
   {"id": "Alice"},
   {"id": "Bob"},
   {"id": "Carol"}
 ];
 
-var links = [
+const links = [
   {"source": 0, "target": 1}, // Alice → Bob
   {"source": 1, "target": 2} // Bob → Carol
 ];
@@ -287,13 +287,13 @@ function id(d) {
 With this accessor, you can use named sources and targets:
 
 ```js
-var nodes = [
+const nodes = [
   {"id": "Alice"},
   {"id": "Bob"},
   {"id": "Carol"}
 ];
 
-var links = [
+const links = [
   {"source": "Alice", "target": "Bob"},
   {"source": "Bob", "target": "Carol"}
 ];


### PR DESCRIPTION
I was reading through this and was struck by lingering use of `var` in the README, so thought I'd submit this PR that upgrades to `let` and `const`.