### PR TITLE
Fix spring force in forceLink.

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -33,8 +33,8 @@ export default function(links) {
     for (var k = 0, n = links.length; k < iterations; ++k) {
       for (var i = 0, link, source, target, x, y, l, b; i < n; ++i) {
         link = links[i], source = link.source, target = link.target;
-        x = target.x + target.vx - source.x - source.vx || jiggle(random);
-        y = target.y + target.vy - source.y - source.vy || jiggle(random);
+        x = target.x - source.x || jiggle(random);
+        y = target.y - source.y || jiggle(random);
         l = Math.sqrt(x * x + y * y);
         l = (l - distances[i]) / l * alpha * strengths[i];
         x *= l, y *= l;


### PR DESCRIPTION
Here is the thing, I think `forceLink` is mean to implement a `spring force`, if so, now code of the force has a issue. 

1. Prove the implementation is spring force

    I just give some reason to prove this is a implementation of spring force, you can skip this part if you alredy believe this.

    According to [Hooke's law](https://en.wikipedia.org/wiki/Hooke%27s_law):
    > F = k * dl // here F is the spring force,k is a positive real number, characteristic of the spring, dl is the delta length of spring.

    And according to [Newton's laws](https://en.wikipedia.org/wiki/Newton%27s_laws_of_motion):
    > F = m * a // here F is force, m is the mass of object, a is acceleration of object

    So we can get `a = k * dl / m`, we can set `strength = k / m`, then get this:

        a = strength * dl

    Then we get delta x and delta y like this:


        // if we alread computed delta x as x, delta y as y
        l = Math.sqrt(x * x + y * y);
       dl = (l - distance);
       acceleration = strength * dl; //              => strength * (l - distance)
       dv = acceleration * dt; //                    => strength * (l  - distance) * dt
       // next (x / l) means get delta in x axis
       dvx = dv * dt * x / l; //                     => x * (l  - distance) * strength  * dt * dt / l
       // next (y / l) means get delta in y axis
       dvy = dv * dt * y / l; //                     => y * (l  - distance) * strength  * dt * dt / l 

    Here we do some change to the variable.

        l = Math.sqrt(x * x + y * y);
        l = (l - distances[i]) / l * strengths[i] * (dt * dt);
        x *= l, y *= l;

    You can see the only difference with here [forceLink code](https://github.com/d3/d3-force/blob/master/src/link.js) is `dt * dt` and `alpha`.

2. **My problem with compute delta x and delta y**

    My problem is here:

        x = target.x - source.x; // instead of target.x + target.vx - source.x - source.vx
        y = target.y - source.y; // insrtead of target.y + target.vy - source.y - source.vy


    If we add `target.vx - source.vx` (call this `dvx`) or `target.vy - source.vy` (call this `dvy`), image that, 

- spring distance is geting larger and larger, so `dlx = target.x - source.x` is getting lagger

- the `velocity` is geting smaller and smaller, so `dvx = target.vx - source.vx` is getting smaller 
- al last, `dlx + dvx` will become smaller, it will make the force become smaller, then the `dx` and `dy` will change less.
