### PR TITLE
Make use of `Math.hypot`

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -35,7 +35,7 @@ export default function(links) {
         link = links[i], source = link.source, target = link.target;
         x = target.x + target.vx - source.x - source.vx || jiggle(random);
         y = target.y + target.vy - source.y - source.vy || jiggle(random);
-        l = Math.sqrt(x * x + y * y);
+        l = Math.hypot(x, y);
         l = (l - distances[i]) / l * alpha * strengths[i];
         x *= l, y *= l;
         target.vx -= x * (b = bias[i]);


### PR DESCRIPTION
Given that `Math.hypot` has been widely available [according to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot), I wonder if it makes sense for `d3` to start using it?

There are probably some other instances where it could be used.